### PR TITLE
Use gold_price_combined_v for gold price data

### DIFF
--- a/lib/features/calculator/infrastructure/datasources/price_datasource.dart
+++ b/lib/features/calculator/infrastructure/datasources/price_datasource.dart
@@ -30,8 +30,8 @@ class PriceDatasource {
   Future<({Map<String, double?> data, DateTime? capturedAt})>
   fetchLatestGold() async {
     final row = await client
-        .from('stg_latest_ticks')
-        .select('captured_at, gold_price, lbma_gold_am, lbma_gold_pm')
+        .from('gold_price_combined_v')
+        .select('captured_at, gold_price, source')
         .order('captured_at', ascending: false)
         .limit(1)
         .maybeSingle();
@@ -42,8 +42,8 @@ class PriceDatasource {
 
     final data = <String, double?>{
       'gold_price': _toD(row?['gold_price']),
-      'lbma_gold_am': _toD(row?['lbma_gold_am']),
-      'lbma_gold_pm': _toD(row?['lbma_gold_pm']),
+      'lbma_gold_am': null,
+      'lbma_gold_pm': null,
     };
 
     return (data: data, capturedAt: capturedAt);

--- a/lib/features/calculator/presentation/viewmodels/parametros_view_model.dart
+++ b/lib/features/calculator/presentation/viewmodels/parametros_view_model.dart
@@ -63,26 +63,24 @@ class ParametrosViewModel extends AsyncNotifier<ParametrosRecomendados> {
     try {
       final client = Supabase.instance.client;
 
-      final latestF = client
+      final rateF = client
           .from('stg_latest_ticks')
           .select('pen_usd')
           .order('captured_at', ascending: false)
           .limit(1)
           .maybeSingle();
 
-      final spotF = client
-          .from('stg_spot_ticks')
-          .select('price')
-          .filter('metal_code', 'in', '("XAU","xau","GOLD","Gold","gold")')
-          .ilike('currency', 'usd')
+      final goldF = client
+          .from('gold_price_combined_v')
+          .select('gold_price')
           .order('captured_at', ascending: false)
           .limit(1)
           .maybeSingle();
 
-      final results = await Future.wait([latestF, spotF]);
+      final results = await Future.wait([rateF, goldF]);
 
       final penUsd = (results[0]?['pen_usd'] as num?)?.toDouble() ?? 0.0;
-      final gold = (results[1]?['price'] as num?)?.toDouble() ?? 0.0;
+      final gold = (results[1]?['gold_price'] as num?)?.toDouble() ?? 0.0;
       final tipoCambio = penUsd;
 
       final data = ParametrosRecomendados.defaults().copyWith(


### PR DESCRIPTION
## Summary
- obtain the default real-time gold price from the gold_price_combined_v view
- rebuild the gold trend chart ranges from the combined view data instead of latest/spot tables
- update the parameters view model to persist the gold price sourced from the combined view

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b2865a0083289a866f40866bbe04