### PR TITLE
Add unit selection to gold trend chart

### DIFF
--- a/lib/features/calculator/presentation/organisms/gold_trend_chart.dart
+++ b/lib/features/calculator/presentation/organisms/gold_trend_chart.dart
@@ -61,6 +61,17 @@ class GoldTrendChart extends ConsumerWidget {
           );
         }
 
+        String unitLabel(GoldUnit unit) {
+          switch (unit) {
+            case GoldUnit.toz:
+              return 'toz';
+            case GoldUnit.gram:
+              return 'g';
+            case GoldUnit.kilogram:
+              return 'kg';
+          }
+        }
+
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -123,6 +134,19 @@ class GoldTrendChart extends ConsumerWidget {
                         DropdownMenuItem(value: 'USD', child: Text('USD')),
                         DropdownMenuItem(value: 'PEN', child: Text('PEN')),
                       ],
+                    ),
+                    const SizedBox(width: 8),
+                    DropdownButton<GoldUnit>(
+                      value: state.unit,
+                      onChanged: (v) => v == null ? null : vm.setUnit(v),
+                      items: GoldUnit.values
+                          .map(
+                            (u) => DropdownMenuItem(
+                              value: u,
+                              child: Text(unitLabel(u)),
+                            ),
+                          )
+                          .toList(),
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Summary
- add a unit dropdown beside the existing time range and currency selectors on the gold trend chart
- recalculate chart points and spot metrics using conversion factors for grams and kilograms derived from troy ounces

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c0c076b48328a356cf44e1be306e