### PR TITLE
Enable Control de Tiempos multi-select and theme awareness

### DIFF
--- a/lib/app/shell/app_shell.dart
+++ b/lib/app/shell/app_shell.dart
@@ -14,6 +14,7 @@ class AppShell extends StatelessWidget {
   final Widget? floatingActionButton;
   final FloatingActionButtonLocation? floatingActionButtonLocation;
   final Widget? bottomNavigationBar;
+  final Color? backgroundColor;
 
   const AppShell({
     super.key,
@@ -27,12 +28,14 @@ class AppShell extends StatelessWidget {
     this.floatingActionButton,
     this.floatingActionButtonLocation,
     this.bottomNavigationBar,
+    this.backgroundColor,
   });
 
   @override
   Widget build(BuildContext context) {
     final size = MediaQuery.of(context).size;
     return Scaffold(
+      backgroundColor: backgroundColor,
       drawer: AppDrawer(
         onGoToCalculadora: onGoToCalculadora,
         onGoToCalendario: onGoToCalendario,

--- a/lib/features/control_tiempos/domain/entities/volquete.dart
+++ b/lib/features/control_tiempos/domain/entities/volquete.dart
@@ -1,15 +1,13 @@
 /// Posibles estados de un volquete dentro del flujo de control de tiempos.
-enum VolqueteEstado { completo, enProceso, pausado }
+enum VolqueteEstado { completo, incompleto }
 
 extension VolqueteEstadoLabel on VolqueteEstado {
   String get label {
     switch (this) {
       case VolqueteEstado.completo:
         return 'Completo';
-      case VolqueteEstado.enProceso:
-        return 'En proceso';
-      case VolqueteEstado.pausado:
-        return 'Pausado';
+      case VolqueteEstado.incompleto:
+        return 'Incompleto';
     }
   }
 }
@@ -43,16 +41,39 @@ extension VolqueteEquipoLabel on VolqueteEquipo {
 }
 
 /// Evento en la línea de tiempo del volquete.
+enum VolqueteEventoIcon { generic, arrow, truckEmpty, truckLoaded, clock, pencil }
+
 class VolqueteEvento {
   const VolqueteEvento({
     required this.titulo,
     required this.descripcion,
     required this.fecha,
+    this.icon = VolqueteEventoIcon.generic,
   });
 
   final String titulo;
   final String descripcion;
   final DateTime fecha;
+  final VolqueteEventoIcon icon;
+}
+
+/// Registro de descarga asociado a un volquete.
+class VolqueteDescarga {
+  const VolqueteDescarga({
+    required this.id,
+    required this.volquete,
+    required this.procedencia,
+    required this.chute,
+    required this.fechaInicio,
+    required this.fechaFin,
+  });
+
+  final String id;
+  final String volquete;
+  final String procedencia;
+  final int chute;
+  final DateTime fechaInicio;
+  final DateTime fechaFin;
 }
 
 /// Entidad de dominio simple para representar un volquete registrado.
@@ -68,6 +89,14 @@ class Volquete {
     required this.tipo,
     required this.equipo,
     required this.eventos,
+    required this.maquinaria,
+    required this.procedencias,
+    required this.chute,
+    required this.llegadaFrente,
+    required this.descargas,
+    this.inicioManiobra,
+    this.inicioCarga,
+    this.finCarga,
     this.documento,
     this.notas,
   });
@@ -82,6 +111,14 @@ class Volquete {
   final VolqueteTipo tipo;
   final VolqueteEquipo equipo;
   final List<VolqueteEvento> eventos;
+  final String maquinaria;
+  final List<String> procedencias;
+  final int chute;
+  final DateTime llegadaFrente;
+  final DateTime? inicioManiobra;
+  final DateTime? inicioCarga;
+  final DateTime? finCarga;
+  final List<VolqueteDescarga> descargas;
   final String? documento;
   final String? notas;
 
@@ -96,6 +133,14 @@ class Volquete {
     VolqueteTipo? tipo,
     VolqueteEquipo? equipo,
     List<VolqueteEvento>? eventos,
+    String? maquinaria,
+    List<String>? procedencias,
+    int? chute,
+    DateTime? llegadaFrente,
+    DateTime? inicioManiobra,
+    DateTime? inicioCarga,
+    DateTime? finCarga,
+    List<VolqueteDescarga>? descargas,
     String? documento,
     String? notas,
   }) {
@@ -110,6 +155,14 @@ class Volquete {
       tipo: tipo ?? this.tipo,
       equipo: equipo ?? this.equipo,
       eventos: eventos ?? this.eventos,
+      maquinaria: maquinaria ?? this.maquinaria,
+      procedencias: procedencias ?? this.procedencias,
+      chute: chute ?? this.chute,
+      llegadaFrente: llegadaFrente ?? this.llegadaFrente,
+      inicioManiobra: inicioManiobra ?? this.inicioManiobra,
+      inicioCarga: inicioCarga ?? this.inicioCarga,
+      finCarga: finCarga ?? this.finCarga,
+      descargas: descargas ?? this.descargas,
       documento: documento ?? this.documento,
       notas: notas ?? this.notas,
     );

--- a/lib/features/control_tiempos/presentation/pages/control_tiempos_page.dart
+++ b/lib/features/control_tiempos/presentation/pages/control_tiempos_page.dart
@@ -9,13 +9,14 @@ import 'package:toolmape/app/shell/app_shell.dart';
 import 'package:toolmape/features/control_tiempos/domain/entities/volquete.dart';
 import 'package:toolmape/features/control_tiempos/presentation/pages/volquete_detail_page.dart';
 import 'package:toolmape/features/control_tiempos/presentation/pages/volquete_form_page.dart';
+import 'package:toolmape/features/control_tiempos/presentation/pages/volquete_info_page.dart';
+import 'package:toolmape/features/control_tiempos/presentation/theme/control_tiempos_palette.dart';
 
-const _iconArrowRight = 'assets/icons/arrow_right.svg';
-const _iconEditPen = 'assets/icons/edit_pen.svg';
-const _iconTruckLoaded = 'assets/icons/truck_large.svg';
-const _iconTruckEmpty = 'assets/icons/truck_small.svg';
+const String _iconArrowRight = 'assets/icons/arrow_right.svg';
+const String _iconTruckEmpty = 'assets/icons/truck_small.svg';
+const String _iconTruckLoaded = 'assets/icons/truck_large.svg';
+const String _iconEditPen = 'assets/icons/edit_pen.svg';
 
-// Nuevos íconos (rama codex)
 const _iconLoaderTab = 'assets/icons/loader_tab.svg';
 const _iconExcavatorTab = 'assets/icons/excavator_tab.svg';
 const _iconExcavatorCarga = 'assets/icons/excavator_carga.svg';
@@ -39,6 +40,8 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
   int _selectedBottomIndex = 0;
   String _searchTerm = '';
   Timer? _debounce;
+  bool _isSelectionMode = false;
+  final Set<String> _selectedVolquetes = <String>{};
 
   VolqueteEquipo get _selectedEquipo =>
       _tabController.index == 0 ? VolqueteEquipo.cargador : VolqueteEquipo.excavadora;
@@ -51,7 +54,7 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
     super.initState();
     _tabController = TabController(length: 2, vsync: this);
     _tabController.addListener(_handleTabChanged);
-    _volquetes = _initialVolquetes;
+    _volquetes = List<Volquete>.from(_initialVolquetes);
   }
 
   @override
@@ -70,21 +73,25 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
 
   void _onSearchChanged(String value) {
     _debounce?.cancel();
-    _debounce = Timer(const Duration(milliseconds: 300), () {
+    _debounce = Timer(const Duration(milliseconds: 250), () {
       setState(() {
         _searchTerm = value.trim().toLowerCase();
       });
     });
   }
 
-  Future<void> _openForm({Volquete? initial}) async {
+  Future<void> _openForm({
+    Volquete? initial,
+    VolqueteFormMode mode = VolqueteFormMode.create,
+  }) async {
     final result = await Navigator.push<Volquete>(
       context,
       MaterialPageRoute(
         builder: (_) => VolqueteFormPage(
           initial: initial,
-          defaultTipo: _selectedTipo,
-          defaultEquipo: _selectedEquipo,
+          defaultTipo: initial?.tipo ?? _selectedTipo,
+          defaultEquipo: initial?.equipo ?? _selectedEquipo,
+          mode: mode,
         ),
       ),
     );
@@ -96,16 +103,17 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
       if (existingIndex >= 0) {
         _volquetes[existingIndex] = result;
       } else {
-        _volquetes = [..._volquetes, result];
+        _volquetes = [result, ..._volquetes];
       }
+      _normalizeSelection();
     });
 
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(initial == null
-            ? 'Volquete registrado correctamente'
-            : 'Volquete actualizado correctamente'),
+            ? 'Nueva carga registrada correctamente'
+            : 'Carga actualizada correctamente'),
       ),
     );
   }
@@ -124,10 +132,11 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
       setState(() {
         _volquetes =
             _volquetes.where((v) => v.id != result.deletedVolqueteId).toList();
+        _normalizeSelection();
       });
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Volquete eliminado')),
+        const SnackBar(content: Text('Registro eliminado.')),
       );
       return;
     }
@@ -135,21 +144,186 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
     if (result.updatedVolquete != null) {
       setState(() {
         final index =
-        _volquetes.indexWhere((v) => v.id == result.updatedVolquete!.id);
+            _volquetes.indexWhere((v) => v.id == result.updatedVolquete!.id);
         if (index >= 0) {
           _volquetes[index] = result.updatedVolquete!;
         }
+        _normalizeSelection();
       });
-      if (!mounted) return;
+    }
+
+    if (result.createdVolquete != null) {
+      setState(() {
+        _volquetes = [result.createdVolquete!, ..._volquetes];
+        _normalizeSelection();
+      });
+    }
+
+    if (!mounted) return;
+    if (result.updatedVolquete != null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Volquete actualizado')),
+        const SnackBar(content: Text('Registro actualizado.')),
+      );
+    } else if (result.createdVolquete != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Nueva carga añadida al listado.')),
       );
     }
+  }
+
+  void _openVolqueteInfo(Volquete volquete) {
+    Navigator.push<void>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => VolqueteInfoPage(volquete: volquete),
+      ),
+    );
   }
 
   void _clearSearch() {
     _searchController.clear();
     _onSearchChanged('');
+  }
+
+  void _refreshList() {
+    setState(() {
+      _volquetes = [..._volquetes]..sort((a, b) => b.fecha.compareTo(a.fecha));
+      _normalizeSelection();
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Listado actualizado.')),
+    );
+  }
+
+  void _registerFinCargaFromList(Volquete volquete) {
+    final DateTime now = DateTime.now();
+    final Volquete updated = volquete.copyWith(
+      finCarga: now,
+      estado: VolqueteEstado.completo,
+      eventos: [
+        ...volquete.eventos,
+        VolqueteEvento(
+          titulo: 'Fin de carga',
+          descripcion: 'Confirmado desde acciones rápidas.',
+          fecha: now,
+          icon: VolqueteEventoIcon.truckLoaded,
+        ),
+      ],
+    );
+
+    setState(() {
+      _volquetes = [
+        for (final item in _volquetes)
+          if (item.id == updated.id) updated else item,
+      ];
+      _normalizeSelection();
+    });
+
+    _showSnack('Fin de carga registrado para ${volquete.codigo}.');
+  }
+
+  void _normalizeSelection() {
+    _selectedVolquetes
+        .removeWhere((id) => !_volquetes.any((volquete) => volquete.id == id));
+  }
+
+  void _toggleSelectionMode() {
+    setState(() {
+      if (_isSelectionMode) {
+        _isSelectionMode = false;
+        _selectedVolquetes.clear();
+      } else {
+        _isSelectionMode = true;
+      }
+    });
+  }
+
+  void _exitSelectionMode() {
+    if (!_isSelectionMode) return;
+    setState(() {
+      _isSelectionMode = false;
+      _selectedVolquetes.clear();
+    });
+  }
+
+  void _toggleVolqueteSelection(Volquete volquete) {
+    setState(() {
+      if (_selectedVolquetes.contains(volquete.id)) {
+        _selectedVolquetes.remove(volquete.id);
+      } else {
+        _selectedVolquetes.add(volquete.id);
+      }
+    });
+  }
+
+  void _handleVolqueteTap(Volquete volquete) {
+    if (_isSelectionMode) {
+      _toggleVolqueteSelection(volquete);
+    } else {
+      _openDetail(volquete);
+    }
+  }
+
+  void _handleVolqueteLongPress(Volquete volquete) {
+    if (_isSelectionMode) {
+      _toggleVolqueteSelection(volquete);
+      return;
+    }
+
+    setState(() {
+      _isSelectionMode = true;
+      _selectedVolquetes
+        ..clear()
+        ..add(volquete.id);
+    });
+  }
+
+  void _markSelectedAsComplete() {
+    if (_selectedVolquetes.isEmpty) return;
+
+    final DateTime now = DateTime.now();
+    setState(() {
+      _volquetes = [
+        for (final volquete in _volquetes)
+          if (_selectedVolquetes.contains(volquete.id))
+            volquete.copyWith(
+              finCarga: now,
+              estado: VolqueteEstado.completo,
+              eventos: [
+                ...volquete.eventos,
+                if (!volquete.eventos.any(
+                  (event) =>
+                      event.icon == VolqueteEventoIcon.truckLoaded &&
+                      event.titulo == 'Fin de carga',
+                ))
+                  VolqueteEvento(
+                    titulo: 'Fin de carga',
+                    descripcion: 'Actualizado desde selección múltiple.',
+                    fecha: now,
+                    icon: VolqueteEventoIcon.truckLoaded,
+                  ),
+              ],
+            )
+          else
+            volquete,
+      ];
+      _normalizeSelection();
+    });
+
+    final int count = _selectedVolquetes.length;
+    _exitSelectionMode();
+    _showSnack(
+      count == 1
+          ? 'Se marcó 1 registro como completo.'
+          : 'Se marcaron $count registros como completos.',
+    );
+  }
+
+  void _clearSelection() {
+    if (_selectedVolquetes.isEmpty) return;
+    setState(() {
+      _selectedVolquetes.clear();
+    });
   }
 
   List<Volquete> get _filteredVolquetes {
@@ -159,19 +333,61 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
       if (_searchTerm.isEmpty) return true;
 
       final term = _searchTerm;
+      final procedencias = volquete.procedencias.join(' ').toLowerCase();
       return volquete.codigo.toLowerCase().contains(term) ||
-          volquete.placa.toLowerCase().contains(term) ||
-          volquete.operador.toLowerCase().contains(term);
+          volquete.maquinaria.toLowerCase().contains(term) ||
+          procedencias.contains(term);
     }).toList();
 
     filtered.sort((a, b) => b.fecha.compareTo(a.fecha));
     return filtered;
   }
 
+  InputDecoration _searchDecoration({
+    required Color fillColor,
+    required Color borderColor,
+    required Color focusBorderColor,
+    required Color iconColor,
+    required Color hintColor,
+  }) {
+    return InputDecoration(
+      hintText: 'Buscar volquete…',
+      prefixIcon: Icon(Icons.search, color: iconColor),
+      suffixIcon: _searchTerm.isEmpty
+          ? null
+          : IconButton(
+              onPressed: _clearSearch,
+              icon: Icon(Icons.clear, color: iconColor),
+            ),
+      filled: true,
+      fillColor: fillColor,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: borderColor),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: borderColor),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: focusBorderColor, width: 2),
+      ),
+      hintStyle: TextStyle(color: hintColor),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = ControlTiemposPalette.of(theme);
+    final textTheme = theme.textTheme;
+    final int selectedCount = _selectedVolquetes.length;
+    final bool hasSelection = selectedCount > 0;
+
     return AppShell(
-      title: 'Control de tiempos',
+      title: 'ToolMAPE',
+      backgroundColor: palette.background,
       onGoToCalculadora: () =>
           Navigator.pushReplacementNamed(context, routeCalculadora),
       onGoToCalendario: () =>
@@ -181,113 +397,200 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
       onGoToInformacion: () =>
           Navigator.pushReplacementNamed(context, routeInformacion),
       floatingActionButton: FloatingActionButton(
+        backgroundColor: palette.accent,
+        foregroundColor: palette.onAccent,
         onPressed: () => _openForm(),
         child: const Icon(Icons.add),
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       bottomNavigationBar: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-          child: Row(
-            children: [
-              Expanded(
-                child: _BottomNavToggleButton(
-                  label: 'Carga',
-                  asset: _iconExcavatorCarga,
-                  isSelected: _selectedBottomIndex == 0,
-                  onTap: () {
-                    if (_selectedBottomIndex != 0) {
-                      setState(() {
-                        _selectedBottomIndex = 0;
-                      });
-                    }
-                  },
-                ),
+        minimum: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: Row(
+          children: [
+            Expanded(
+              child: _BottomNavToggleButton(
+                label: 'Carga',
+                asset: _iconExcavatorCarga,
+                isSelected: _selectedBottomIndex == 0,
+                onTap: () {
+                  if (_selectedBottomIndex != 0) {
+                    setState(() {
+                      _selectedBottomIndex = 0;
+                    });
+                  }
+                },
+                palette: palette,
               ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: _BottomNavToggleButton(
-                  label: 'Descarga',
-                  asset: _iconExcavatorDescarga,
-                  isSelected: _selectedBottomIndex == 1,
-                  onTap: () {
-                    if (_selectedBottomIndex != 1) {
-                      setState(() {
-                        _selectedBottomIndex = 1;
-                      });
-                    }
-                  },
-                ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: _BottomNavToggleButton(
+                label: 'Descarga',
+                asset: _iconExcavatorDescarga,
+                isSelected: _selectedBottomIndex == 1,
+                onTap: () {
+                  if (_selectedBottomIndex != 1) {
+                    setState(() {
+                      _selectedBottomIndex = 1;
+                    });
+                  }
+                },
+                palette: palette,
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
       body: SafeArea(
-        child: Padding(
+        child: Container(
+          color: palette.background,
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              TabBar(
-                controller: _tabController,
-                tabs: const [
-                  Tab(
-                    child: _TabIconLabel(
-                      asset: _iconLoaderTab,
-                      label: 'Cargador',
+              Container(
+                decoration: BoxDecoration(
+                  color: palette.tabContainer,
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                padding: const EdgeInsets.all(8),
+                child: TabBar(
+                  controller: _tabController,
+                  indicator: BoxDecoration(
+                    color: palette.accent,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  indicatorSize: TabBarIndicatorSize.tab,
+                  labelColor: palette.onAccent,
+                  unselectedLabelColor: palette.mutedText,
+                  tabs: const [
+                    Tab(
+                      child: _TabIconLabel(
+                        asset: _iconLoaderTab,
+                        label: 'Cargador',
+                      ),
+                    ),
+                    Tab(
+                      child: _TabIconLabel(
+                        asset: _iconExcavatorTab,
+                        label: 'Excavadora',
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _searchController,
+                      onChanged: _onSearchChanged,
+                      style: TextStyle(color: palette.primaryText),
+                      decoration: _searchDecoration(
+                        fillColor: palette.searchFill,
+                        borderColor: palette.outline,
+                        focusBorderColor: palette.accent,
+                        iconColor: palette.mutedText,
+                        hintColor: palette.hint,
+                      ),
                     ),
                   ),
-                  Tab(
-                    child: _TabIconLabel(
-                      asset: _iconExcavatorTab,
-                      label: 'Excavadora',
+                  const SizedBox(width: 12),
+                  OutlinedButton.icon(
+                    onPressed: _toggleSelectionMode,
+                    icon: Icon(
+                      _isSelectionMode
+                          ? Icons.close
+                          : Icons.checklist_rtl_rounded,
                     ),
+                    label: Text(
+                        _isSelectionMode ? 'Cancelar' : 'Seleccionar'),
+                  ),
+                  if (_isSelectionMode) ...[
+                    const SizedBox(width: 12),
+                    FilledButton.icon(
+                      onPressed: hasSelection ? _markSelectedAsComplete : null,
+                      icon: const Icon(Icons.done_all),
+                      label: const Text('Completar'),
+                    ),
+                  ],
+                  const SizedBox(width: 12),
+                  IconButton(
+                    onPressed: _refreshList,
+                    icon: Icon(Icons.refresh, color: palette.icon),
+                    tooltip: 'Actualizar',
                   ),
                 ],
               ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: _searchController,
-                onChanged: _onSearchChanged,
-                decoration: InputDecoration(
-                  hintText: 'Buscar volquete…',
-                  prefixIcon: const Icon(Icons.search),
-                  suffixIcon: _searchTerm.isEmpty
-                      ? null
-                      : IconButton(
-                    onPressed: _clearSearch,
-                    icon: const Icon(Icons.clear),
-                  ),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
+              if (_isSelectionMode)
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          hasSelection
+                              ? '$selectedCount registro${selectedCount == 1 ? '' : 's'} seleccionados.'
+                              : 'Selecciona registros para aplicar acciones masivas.',
+                          style: textTheme.bodyMedium?.copyWith(
+                            color: palette.mutedText,
+                            fontWeight: hasSelection
+                                ? FontWeight.w600
+                                : FontWeight.w500,
+                          ),
+                        ),
+                      ),
+                      if (hasSelection)
+                        TextButton(
+                          onPressed: _clearSelection,
+                          child: const Text('Limpiar'),
+                        ),
+                    ],
                   ),
                 ),
-              ),
               const SizedBox(height: 16),
               Expanded(
                 child: _filteredVolquetes.isEmpty
-                    ? const _EmptyVolquetesView()
+                    ? _EmptyVolquetesView(palette: palette)
                     : ListView.separated(
-                  itemCount: _filteredVolquetes.length,
-                  separatorBuilder: (_, __) => const SizedBox(height: 12),
-                  itemBuilder: (_, index) {
-                    final volquete = _filteredVolquetes[index];
-                    return _VolqueteCard(
-                      volquete: volquete,
-                      dateFormat: _dateFormat,
-                      onTap: () => _openDetail(volquete),
-                      onEdit: () => _openForm(initial: volquete),
-                      onViewDocument: () => _showSnack(
-                        'Documento ${volquete.documento ?? 'no disponible'}',
+                        itemCount: _filteredVolquetes.length,
+                        separatorBuilder: (_, __) =>
+                            const SizedBox(height: 12),
+                        itemBuilder: (_, index) {
+                          final volquete = _filteredVolquetes[index];
+                          return _VolqueteCard(
+                            volquete: volquete,
+                            dateFormat: _dateFormat,
+                            onTap: () => _handleVolqueteTap(volquete),
+                            onLongPress: () =>
+                                _handleVolqueteLongPress(volquete),
+                            onEdit: () => _openForm(
+                              initial: volquete,
+                              mode: VolqueteFormMode.edit,
+                            ),
+                            onViewVolquete: () => _openVolqueteInfo(volquete),
+                            onStartManiobra: () => _showSnack(
+                              'Inicio de maniobra registrado para ${volquete.codigo}.',
+                            ),
+                            onStartCarga: () => _showSnack(
+                              'Inicio de carga marcado para ${volquete.codigo}.',
+                            ),
+                            onEndCarga: () =>
+                                _registerFinCargaFromList(volquete),
+                            onFinishOperacion: () => _showSnack(
+                              'Operación finalizada para ${volquete.codigo}.',
+                            ),
+                            isSelectionMode: _isSelectionMode,
+                            isSelected:
+                                _selectedVolquetes.contains(volquete.id),
+                            onToggleSelection: () =>
+                                _toggleVolqueteSelection(volquete),
+                            palette: palette,
+                          );
+                        },
                       ),
-                      onViewVolquete: () => _openDetail(volquete),
-                      onNavigate: () => _showSnack(
-                        'Navegando a ${volquete.destino}',
-                      ),
-                    );
-                  },
-                ),
               ),
             ],
           ),
@@ -309,18 +612,21 @@ class _BottomNavToggleButton extends StatelessWidget {
     required this.asset,
     required this.isSelected,
     required this.onTap,
+    required this.palette,
   });
 
   final String label;
   final String asset;
   final bool isSelected;
   final VoidCallback onTap;
+  final ControlTiemposPalette palette;
 
   @override
   Widget build(BuildContext context) {
-    const Color selectedBackground = Color(0xFFF97316);
-    const Color unselectedBackground = Color(0xFF1F2937);
-    final Color background = isSelected ? selectedBackground : unselectedBackground;
+    final Color background =
+        isSelected ? palette.accent : palette.surface;
+    final Color foreground =
+        isSelected ? palette.onAccent : palette.mutedText;
 
     return Material(
       color: background,
@@ -329,7 +635,7 @@ class _BottomNavToggleButton extends StatelessWidget {
         onTap: onTap,
         borderRadius: BorderRadius.circular(16),
         child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 14),
+          padding: const EdgeInsets.symmetric(vertical: 12),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -337,15 +643,15 @@ class _BottomNavToggleButton extends StatelessWidget {
                 asset,
                 width: 28,
                 height: 28,
-                colorFilter: const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+                colorFilter: ColorFilter.mode(foreground, BlendMode.srcIn),
               ),
               const SizedBox(height: 8),
               Text(
                 label,
                 style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                  color: Colors.white,
-                  fontWeight: FontWeight.w600,
-                ),
+                      color: foreground,
+                      fontWeight: FontWeight.w600,
+                    ),
               ),
             ],
           ),
@@ -363,32 +669,33 @@ class _TabIconLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Color iconColor =
-        IconTheme.of(context).color ?? Theme.of(context).colorScheme.onSurface;
-    final TextStyle textStyle = DefaultTextStyle.of(context).style;
-    final Color resolvedTextColor = textStyle.color ?? iconColor;
+    final Color color = DefaultTextStyle.of(context).style.color ??
+        Theme.of(context).colorScheme.onSurface;
+    final TextStyle textStyle =
+        Theme.of(context).textTheme.labelLarge?.copyWith(color: color) ??
+            TextStyle(color: color);
 
     return Row(
       mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
       children: [
         SvgPicture.asset(
           asset,
           width: 20,
           height: 20,
-          colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
+          colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
         ),
         const SizedBox(width: 8),
-        Text(
-          label,
-          style: textStyle.copyWith(color: resolvedTextColor),
-        ),
+        Text(label, style: textStyle),
       ],
     );
   }
 }
 
 class _EmptyVolquetesView extends StatelessWidget {
-  const _EmptyVolquetesView();
+  const _EmptyVolquetesView({required this.palette});
+
+  final ControlTiemposPalette palette;
 
   @override
   Widget build(BuildContext context) {
@@ -396,16 +703,21 @@ class _EmptyVolquetesView extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Icons.inbox_outlined, size: 64, color: Colors.grey.shade400),
+          Icon(Icons.inbox_outlined, size: 64, color: palette.emptyIcon),
           const SizedBox(height: 12),
-          const Text('No se encontraron registros'),
+          Text(
+            'No se encontraron registros',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: palette.mutedText,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
           const SizedBox(height: 4),
           Text(
             'Ajusta los filtros o registra un nuevo volquete.',
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium
-                ?.copyWith(color: Colors.grey.shade600),
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: palette.subtleText,
+                ),
             textAlign: TextAlign.center,
           ),
         ],
@@ -419,185 +731,275 @@ class _VolqueteCard extends StatelessWidget {
     required this.volquete,
     required this.dateFormat,
     required this.onTap,
+    required this.onLongPress,
     required this.onEdit,
-    required this.onViewDocument,
     required this.onViewVolquete,
-    required this.onNavigate,
+    required this.onStartManiobra,
+    required this.onStartCarga,
+    required this.onEndCarga,
+    required this.onFinishOperacion,
+    required this.isSelectionMode,
+    required this.isSelected,
+    required this.onToggleSelection,
+    required this.palette,
   });
 
   final Volquete volquete;
   final DateFormat dateFormat;
   final VoidCallback onTap;
+  final VoidCallback onLongPress;
   final VoidCallback onEdit;
-  final VoidCallback onViewDocument;
   final VoidCallback onViewVolquete;
-  final VoidCallback onNavigate;
+  final VoidCallback onStartManiobra;
+  final VoidCallback onStartCarga;
+  final VoidCallback onEndCarga;
+  final VoidCallback onFinishOperacion;
+  final bool isSelectionMode;
+  final bool isSelected;
+  final VoidCallback onToggleSelection;
+  final ControlTiemposPalette palette;
 
   @override
   Widget build(BuildContext context) {
-    final Color iconColor =
-        Theme.of(context).iconTheme.color ?? Theme.of(context).colorScheme.onSurface;
-    final bool isDescarga = volquete.tipo == VolqueteTipo.descarga;
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final Color cardColor = isSelected
+        ? Color.alphaBlend(palette.selectionFill, palette.surface)
+        : palette.surface;
+    final BorderSide borderSide = BorderSide(
+      color: isSelected ? palette.selectionBorder : palette.outline,
+      width: isSelected ? 1.5 : 1,
+    );
+    final EdgeInsets padding =
+        isSelectionMode ? const EdgeInsets.fromLTRB(56, 16, 16, 16) : const EdgeInsets.all(16);
 
-    final List<_VolqueteCardAction> actions = isDescarga
-        ? [
-            _VolqueteCardAction(
-              tooltip: 'Llegada al chute',
-              asset: _iconTruckLoaded,
-              onPressed: onViewVolquete,
-            ),
-            _VolqueteCardAction(
-              tooltip: 'Fin de descarga',
-              asset: _iconTruckEmpty,
-              onPressed: onViewDocument,
-            ),
-            _VolqueteCardAction(
-              tooltip: 'Maniobra de salida',
-              asset: _iconArrowRight,
-              onPressed: onNavigate,
-            ),
-            _VolqueteCardAction(
-              tooltip: 'Editar',
-              asset: _iconEditPen,
-              onPressed: onEdit,
-            ),
-          ]
-        : [
-            _VolqueteCardAction(
-              tooltip: 'Inicio de maniobra',
-              asset: _iconArrowRight,
-              onPressed: onViewVolquete,
-            ),
-            _VolqueteCardAction(
-              tooltip: 'Inicio de carga',
-              asset: _iconExcavatorCarga,
-              onPressed: onViewDocument,
-            ),
-            _VolqueteCardAction(
-              tooltip: 'Final de carga',
-              asset: _iconExcavatorDescarga,
-              onPressed: onNavigate,
-            ),
-            _VolqueteCardAction(
-              tooltip: 'Editar',
-              asset: _iconEditPen,
-              onPressed: onEdit,
-            ),
-          ];
+    final TextStyle titleStyle = textTheme.titleMedium?.copyWith(
+          color: palette.primaryText,
+          fontWeight: FontWeight.w700,
+        ) ??
+        TextStyle(color: palette.primaryText, fontWeight: FontWeight.w700);
+    final TextStyle detailStyle =
+        textTheme.bodySmall?.copyWith(color: palette.mutedText) ??
+            TextStyle(color: palette.mutedText);
+    final TextStyle subtleStyle =
+        textTheme.bodySmall?.copyWith(color: palette.subtleText) ??
+            TextStyle(color: palette.subtleText);
 
-    Widget buildActionButton(_VolqueteCardAction action) {
-      return IconButton(
-        tooltip: action.tooltip,
-        onPressed: action.onPressed,
-        icon: SvgPicture.asset(
-          action.asset,
-          width: 24,
-          height: 24,
-          colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
-        ),
-      );
-    }
-
-    Widget buildTrailing() {
-      if (!isDescarga) {
-        return Wrap(
-          spacing: 4,
-          runSpacing: 4,
-          children: actions.map(buildActionButton).toList(),
-        );
-      }
-
-      final String estadoLabel =
-          volquete.estado == VolqueteEstado.completo ? 'Completo' : 'Incompleto';
-
-      Color estadoColor() {
-        switch (volquete.estado) {
-          case VolqueteEstado.completo:
-            return Colors.green.shade600;
-          case VolqueteEstado.enProceso:
-            return Colors.orange.shade600;
-          case VolqueteEstado.pausado:
-            return Colors.blueGrey.shade600;
-        }
-      }
-
-      return Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          Text(
-            estadoLabel,
-            style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: estadoColor(),
-                ),
-          ),
-          const SizedBox(height: 8),
-          Wrap(
-            spacing: 4,
-            runSpacing: 4,
-            children: actions.map(buildActionButton).toList(),
-          ),
-        ],
-      );
-    }
-
-    return Card(
-      elevation: 0,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+    return Material(
+      color: Colors.transparent,
       child: InkWell(
+        onTap: isSelectionMode ? onToggleSelection : onTap,
+        onLongPress: onLongPress,
         borderRadius: BorderRadius.circular(16),
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
+        child: Stack(
+          children: [
+            Container(
+              padding: padding,
+              decoration: BoxDecoration(
+                color: cardColor,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.fromBorderSide(borderSide),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: GestureDetector(
+                          onTap: onViewVolquete,
                           child: Text(
                             volquete.codigo,
-                            style: Theme.of(context).textTheme.titleMedium,
+                            style: titleStyle,
                           ),
                         ),
-                        if (!isDescarga) ...[
-                          const SizedBox(width: 12),
-                          _EstadoChip(estado: volquete.estado),
+                      ),
+                      const SizedBox(width: 12),
+                      _StatusText(estado: volquete.estado, palette: palette),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              dateFormat.format(volquete.fecha),
+                              style: subtleStyle,
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              '${volquete.maquinaria} • Chute ${volquete.chute}',
+                              style: detailStyle,
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              volquete.procedencias.join(' / '),
+                              style: detailStyle,
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          _ActionIconButton(
+                            tooltip: 'Inicio de maniobra',
+                            onPressed: onStartManiobra,
+                            icon: SvgPicture.asset(
+                              _iconArrowRight,
+                              width: 22,
+                              height: 22,
+                              colorFilter:
+                                  ColorFilter.mode(palette.icon, BlendMode.srcIn),
+                            ),
+                          ),
+                          const SizedBox(width: 6),
+                          _ActionIconButton(
+                            tooltip: 'Inicio de carga',
+                            onPressed: onStartCarga,
+                            icon: SvgPicture.asset(
+                              _iconTruckEmpty,
+                              width: 22,
+                              height: 22,
+                              colorFilter:
+                                  ColorFilter.mode(palette.icon, BlendMode.srcIn),
+                            ),
+                          ),
+                          const SizedBox(width: 6),
+                          _ActionIconButton(
+                            tooltip: 'Fin de carga',
+                            onPressed: onEndCarga,
+                            icon: SvgPicture.asset(
+                              _iconTruckLoaded,
+                              width: 22,
+                              height: 22,
+                              colorFilter:
+                                  ColorFilter.mode(palette.icon, BlendMode.srcIn),
+                            ),
+                          ),
+                          const SizedBox(width: 6),
+                          _ActionIconButton(
+                            tooltip: 'Finalizar operación',
+                            onPressed: onFinishOperacion,
+                            icon: Icon(
+                              Icons.timer_outlined,
+                              color: palette.icon,
+                              size: 22,
+                            ),
+                          ),
+                          const SizedBox(width: 6),
+                          _ActionIconButton(
+                            tooltip: 'Editar',
+                            onPressed: onEdit,
+                            icon: SvgPicture.asset(
+                              _iconEditPen,
+                              width: 22,
+                              height: 22,
+                              colorFilter:
+                                  ColorFilter.mode(palette.icon, BlendMode.srcIn),
+                            ),
+                          ),
                         ],
-                      ],
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      '${volquete.placa} • ${volquete.operador}',
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      dateFormat.format(volquete.fecha),
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodySmall
-                          ?.copyWith(color: Colors.grey.shade600),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      'Destino: ${volquete.destino}',
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodySmall
-                          ?.copyWith(color: Colors.grey.shade600),
-                    ),
-                  ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            if (isSelectionMode)
+              Positioned(
+                top: 16,
+                left: 16,
+                child: _SelectionIndicator(
+                  selected: isSelected,
+                  palette: palette,
+                  onPressed: onToggleSelection,
                 ),
               ),
-              const SizedBox(width: 12),
-              buildTrailing(),
-            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusText extends StatelessWidget {
+  const _StatusText({required this.estado, required this.palette});
+
+  final VolqueteEstado estado;
+  final ControlTiemposPalette palette;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool completo = estado == VolqueteEstado.completo;
+    final Color color = completo ? palette.success : palette.accent;
+
+    return Text(
+      estado.label,
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: color,
+            fontWeight: FontWeight.w700,
+          ) ??
+          TextStyle(color: color, fontWeight: FontWeight.w700),
+    );
+  }
+}
+
+class _SelectionIndicator extends StatelessWidget {
+  const _SelectionIndicator({
+    required this.selected,
+    required this.palette,
+    required this.onPressed,
+  });
+
+  final bool selected;
+  final ControlTiemposPalette palette;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(12),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+          width: 28,
+          height: 28,
+          decoration: BoxDecoration(
+            color: selected
+                ? palette.accent
+                : palette.surface.withOpacity(0.2),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: selected ? palette.selectionBorder : palette.outline,
+              width: selected ? 1.3 : 1,
+            ),
+          ),
+          alignment: Alignment.center,
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 200),
+            child: selected
+                ? Icon(
+                    Icons.check,
+                    key: const ValueKey(true),
+                    color: palette.onAccent,
+                    size: 18,
+                  )
+                : Icon(
+                    Icons.circle_outlined,
+                    key: const ValueKey(false),
+                    color: palette.mutedText,
+                    size: 18,
+                  ),
           ),
         ),
       ),
@@ -605,59 +1007,27 @@ class _VolqueteCard extends StatelessWidget {
   }
 }
 
-class _VolqueteCardAction {
-  const _VolqueteCardAction({
+class _ActionIconButton extends StatelessWidget {
+  const _ActionIconButton({
     required this.tooltip,
-    required this.asset,
     required this.onPressed,
+    required this.icon,
   });
 
   final String tooltip;
-  final String asset;
   final VoidCallback onPressed;
-}
-
-class _EstadoChip extends StatelessWidget {
-  const _EstadoChip({required this.estado});
-
-  final VolqueteEstado estado;
-
-  Color _backgroundColor(BuildContext context) {
-    switch (estado) {
-      case VolqueteEstado.completo:
-        return Colors.green.shade100;
-      case VolqueteEstado.enProceso:
-        return Colors.orange.shade100;
-      case VolqueteEstado.pausado:
-        return Colors.blueGrey.shade100;
-    }
-  }
-
-  Color _textColor() {
-    switch (estado) {
-      case VolqueteEstado.completo:
-        return Colors.green.shade800;
-      case VolqueteEstado.enProceso:
-        return Colors.orange.shade800;
-      case VolqueteEstado.pausado:
-        return Colors.blueGrey.shade800;
-    }
-  }
+  final Widget icon;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-      decoration: BoxDecoration(
-        color: _backgroundColor(context),
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Text(
-        estado.label,
-        style: Theme.of(context)
-            .textTheme
-            .labelSmall
-            ?.copyWith(fontWeight: FontWeight.w600, color: _textColor()),
+    return Tooltip(
+      message: tooltip,
+      child: IconButton(
+        onPressed: onPressed,
+        icon: icon,
+        visualDensity: VisualDensity.compact,
+        splashRadius: 22,
+        padding: EdgeInsets.zero,
       ),
     );
   }
@@ -665,146 +1035,330 @@ class _EstadoChip extends StatelessWidget {
 
 final List<Volquete> _initialVolquetes = [
   Volquete(
-    id: 'v09',
-    codigo: '(V09) Volq. JAA X3U-843',
-    placa: 'JAA X3U-843',
-    operador: 'Carlos Velarde',
-    destino: 'Frente 12 - Zona A',
-    fecha: DateTime(2025, 3, 27, 15, 30),
-    estado: VolqueteEstado.completo,
+    id: 'v10',
+    codigo: '(V10) Volq. MG B9G-917',
+    placa: 'MG B9G-917',
+    operador: '(E01) Excav. C 340-01',
+    destino: 'Beatriz 1',
+    fecha: DateTime(2025, 7, 22, 8, 45, 39),
+    estado: VolqueteEstado.incompleto,
     tipo: VolqueteTipo.carga,
     equipo: VolqueteEquipo.cargador,
-    documento: 'OrdenCarga_V09.pdf',
+    maquinaria: '(E01) Excav. C 340-01',
+    procedencias: const ['Beatriz 1'],
+    chute: 3,
+    llegadaFrente: DateTime(2025, 7, 22, 8, 40),
+    inicioManiobra: DateTime(2025, 7, 22, 8, 42),
+    inicioCarga: DateTime(2025, 7, 22, 8, 47),
+    finCarga: null,
+    documento: 'OT-000912.pdf',
+    notas: 'Operación en espera de confirmación de balanza.',
     eventos: [
       VolqueteEvento(
-        titulo: 'Carga completada',
-        descripcion: 'Carga registrada por operador en turno matutino.',
-        fecha: DateTime(2025, 3, 27, 15, 20),
+        titulo: 'Ingreso a frente',
+        descripcion: 'Arribo a zona Beatriz 1 con guía interna 00124.',
+        fecha: DateTime(2025, 7, 22, 8, 40),
+        icon: VolqueteEventoIcon.arrow,
       ),
       VolqueteEvento(
-        titulo: 'Salida hacia depósito',
-        descripcion: 'Salida autorizada con guía interna 000912.',
-        fecha: DateTime(2025, 3, 27, 15, 30),
+        titulo: 'Preparación para carga',
+        descripcion: 'Asignado al chute 3.',
+        fecha: DateTime(2025, 7, 22, 8, 42),
+        icon: VolqueteEventoIcon.truckEmpty,
+      ),
+    ],
+    descargas: [
+      VolqueteDescarga(
+        id: 'd100',
+        volquete: '(V10) Volq. MG B9G-917',
+        procedencia: 'Beatriz 1',
+        chute: 3,
+        fechaInicio: DateTime(2025, 7, 21, 23, 20),
+        fechaFin: DateTime(2025, 7, 21, 23, 54),
+      ),
+      VolqueteDescarga(
+        id: 'd101',
+        volquete: '(V07) Volq. MG B9G-917',
+        procedencia: 'Beatriz 2',
+        chute: 2,
+        fechaInicio: DateTime(2025, 7, 20, 21, 15),
+        fechaFin: DateTime(2025, 7, 20, 21, 44),
       ),
     ],
   ),
   Volquete(
-    id: 'v05',
-    codigo: '(V05) Volq. GQ VQN-840',
-    placa: 'GQ VQN-840',
-    operador: 'Ana Espino',
-    destino: 'Depósito central',
-    fecha: DateTime(2025, 3, 27, 14, 45),
-    estado: VolqueteEstado.enProceso,
+    id: 'v08',
+    codigo: '(V08) Volq. GQ VON-840',
+    placa: 'GQ VON-840',
+    operador: '(E03) Carg. AD L150F',
+    destino: 'Panchita 2',
+    fecha: DateTime(2025, 7, 16, 9, 8, 22),
+    estado: VolqueteEstado.completo,
     tipo: VolqueteTipo.carga,
     equipo: VolqueteEquipo.cargador,
-    documento: 'OrdenCarga_V05.pdf',
+    maquinaria: '(E03) Carg. AD L150F',
+    procedencias: const ['Panchita 2'],
+    chute: 4,
+    llegadaFrente: DateTime(2025, 7, 16, 8, 55),
+    inicioManiobra: DateTime(2025, 7, 16, 8, 57),
+    inicioCarga: DateTime(2025, 7, 16, 9, 1),
+    finCarga: DateTime(2025, 7, 16, 9, 8),
+    documento: 'OT-000898.pdf',
+    notas: 'Carga confirmada y sellada.',
     eventos: [
       VolqueteEvento(
-        titulo: 'Ingreso a carguío',
-        descripcion: 'Arribo al frente con orden de servicio 000234.',
-        fecha: DateTime(2025, 3, 27, 14, 10),
+        titulo: 'Inicio de maniobra',
+        descripcion: 'Se posiciona en el chute 4.',
+        fecha: DateTime(2025, 7, 16, 8, 57),
+        icon: VolqueteEventoIcon.arrow,
       ),
       VolqueteEvento(
-        titulo: 'Pesaje preliminar',
-        descripcion: 'Peso registrado 18.2 tn.',
-        fecha: DateTime(2025, 3, 27, 14, 40),
+        titulo: 'Fin de carga',
+        descripcion: 'Carga completada y verificada.',
+        fecha: DateTime(2025, 7, 16, 9, 8),
+        icon: VolqueteEventoIcon.truckLoaded,
+      ),
+    ],
+    descargas: [
+      VolqueteDescarga(
+        id: 'd102',
+        volquete: '(V08) Volq. GQ VON-840',
+        procedencia: 'Panchita 2',
+        chute: 4,
+        fechaInicio: DateTime(2025, 7, 15, 18, 10),
+        fechaFin: DateTime(2025, 7, 15, 18, 40),
+      ),
+      VolqueteDescarga(
+        id: 'd103',
+        volquete: '(V05) Volq. GQ VON-840',
+        procedencia: 'Beatriz 3',
+        chute: 5,
+        fechaInicio: DateTime(2025, 7, 14, 20, 5),
+        fechaFin: DateTime(2025, 7, 14, 20, 45),
+      ),
+    ],
+  ),
+  Volquete(
+    id: 'v04',
+    codigo: '(V04) Volq. FR D7V-760',
+    placa: 'FR D7V-760',
+    operador: '(E02) Excav. ZX 350',
+    destino: 'Beatriz 2',
+    fecha: DateTime(2025, 7, 16, 9, 2, 12),
+    estado: VolqueteEstado.incompleto,
+    tipo: VolqueteTipo.carga,
+    equipo: VolqueteEquipo.excavadora,
+    maquinaria: '(E02) Excav. ZX 350',
+    procedencias: const ['Beatriz 2', 'Relavado'],
+    chute: 2,
+    llegadaFrente: DateTime(2025, 7, 16, 8, 48),
+    inicioManiobra: DateTime(2025, 7, 16, 8, 50),
+    inicioCarga: DateTime(2025, 7, 16, 8, 56),
+    finCarga: null,
+    documento: 'OT-000876.pdf',
+    notas: 'Pendiente consolidar tonelaje final.',
+    eventos: [
+      VolqueteEvento(
+        titulo: 'Ingreso a zona',
+        descripcion: 'Verificación de neumáticos completada.',
+        fecha: DateTime(2025, 7, 16, 8, 48),
+        icon: VolqueteEventoIcon.arrow,
+      ),
+      VolqueteEvento(
+        titulo: 'Inicio de carga',
+        descripcion: 'Excavadora ZX 350 inicia turno.',
+        fecha: DateTime(2025, 7, 16, 8, 56),
+        icon: VolqueteEventoIcon.truckEmpty,
+      ),
+    ],
+    descargas: [
+      VolqueteDescarga(
+        id: 'd104',
+        volquete: '(V04) Volq. FR D7V-760',
+        procedencia: 'Beatriz 2',
+        chute: 2,
+        fechaInicio: DateTime(2025, 7, 12, 7, 30),
+        fechaFin: DateTime(2025, 7, 12, 7, 58),
+      ),
+      VolqueteDescarga(
+        id: 'd105',
+        volquete: '(V04) Volq. FR D7V-760',
+        procedencia: 'Relavado',
+        chute: 1,
+        fechaInicio: DateTime(2025, 7, 11, 22, 15),
+        fechaFin: DateTime(2025, 7, 11, 22, 44),
+      ),
+    ],
+  ),
+  Volquete(
+    id: 'v03',
+    codigo: '(V03) Volq. SR V3R-770',
+    placa: 'SR V3R-770',
+    operador: '(E03) Carg. AD L150F',
+    destino: 'Beatriz 3',
+    fecha: DateTime(2025, 7, 16, 8, 58, 2),
+    estado: VolqueteEstado.completo,
+    tipo: VolqueteTipo.descarga,
+    equipo: VolqueteEquipo.cargador,
+    maquinaria: '(E03) Carg. AD L150F',
+    procedencias: const ['Beatriz 3'],
+    chute: 5,
+    llegadaFrente: DateTime(2025, 7, 16, 8, 30),
+    inicioManiobra: DateTime(2025, 7, 16, 8, 32),
+    inicioCarga: DateTime(2025, 7, 16, 8, 34),
+    finCarga: DateTime(2025, 7, 16, 8, 58),
+    documento: 'OT-000854.pdf',
+    notas: 'Descarga cerrada y aprobada.',
+    eventos: [
+      VolqueteEvento(
+        titulo: 'Inicio descarga',
+        descripcion: 'Ingreso a patio de maniobras.',
+        fecha: DateTime(2025, 7, 16, 8, 40),
+        icon: VolqueteEventoIcon.truckLoaded,
+      ),
+      VolqueteEvento(
+        titulo: 'Finalización',
+        descripcion: 'Peso registrado 18.7 tn.',
+        fecha: DateTime(2025, 7, 16, 8, 58),
+        icon: VolqueteEventoIcon.clock,
+      ),
+    ],
+    descargas: [
+      VolqueteDescarga(
+        id: 'd106',
+        volquete: '(V03) Volq. SR V3R-770',
+        procedencia: 'Beatriz 3',
+        chute: 5,
+        fechaInicio: DateTime(2025, 7, 13, 12, 5),
+        fechaFin: DateTime(2025, 7, 13, 12, 32),
       ),
     ],
   ),
   Volquete(
     id: 'v02',
-    codigo: '(V02) Volq. RD F7V-760',
-    placa: 'RD F7V-760',
-    operador: 'Luis Ramos',
-    destino: 'Botadero norte',
-    fecha: DateTime(2025, 3, 27, 13, 10),
-    estado: VolqueteEstado.pausado,
-    tipo: VolqueteTipo.carga,
-    equipo: VolqueteEquipo.cargador,
-    documento: 'OrdenCarga_V02.pdf',
+    codigo: '(V02) Volq. NG F1X-794',
+    placa: 'NG F1X-794',
+    operador: '(E01) Excav. C 340-01',
+    destino: 'Panchita 1',
+    fecha: DateTime(2025, 7, 16, 8, 55, 10),
+    estado: VolqueteEstado.incompleto,
+    tipo: VolqueteTipo.descarga,
+    equipo: VolqueteEquipo.excavadora,
+    maquinaria: '(E01) Excav. C 340-01',
+    procedencias: const ['Panchita 1'],
+    chute: 1,
+    llegadaFrente: DateTime(2025, 7, 16, 8, 15),
+    inicioManiobra: DateTime(2025, 7, 16, 8, 18),
+    inicioCarga: DateTime(2025, 7, 16, 8, 24),
+    finCarga: null,
+    documento: 'OT-000833.pdf',
+    notas: 'Esperando confirmación de seguridad.',
     eventos: [
       VolqueteEvento(
-        titulo: 'Inicio de carga',
-        descripcion: 'Inicio autorizado por supervisor.',
-        fecha: DateTime(2025, 3, 27, 12, 50),
+        titulo: 'Ingreso a zona',
+        descripcion: 'Tránsito con acompañamiento.',
+        fecha: DateTime(2025, 7, 16, 8, 15),
+        icon: VolqueteEventoIcon.arrow,
+      ),
+    ],
+    descargas: [
+      VolqueteDescarga(
+        id: 'd107',
+        volquete: '(V02) Volq. NG F1X-794',
+        procedencia: 'Panchita 1',
+        chute: 1,
+        fechaInicio: DateTime(2025, 7, 14, 14, 40),
+        fechaFin: DateTime(2025, 7, 14, 15, 5),
+      ),
+    ],
+  ),
+  Volquete(
+    id: 'v01',
+    codigo: '(V01) Volq. SR V3R-770',
+    placa: 'SR V3R-770',
+    operador: '(E02) Excav. ZX 350',
+    destino: 'Relavado',
+    fecha: DateTime(2025, 7, 16, 8, 54, 44),
+    estado: VolqueteEstado.completo,
+    tipo: VolqueteTipo.carga,
+    equipo: VolqueteEquipo.excavadora,
+    maquinaria: '(E02) Excav. ZX 350',
+    procedencias: const ['Relavado'],
+    chute: 4,
+    llegadaFrente: DateTime(2025, 7, 16, 8, 12),
+    inicioManiobra: DateTime(2025, 7, 16, 8, 16),
+    inicioCarga: DateTime(2025, 7, 16, 8, 19),
+    finCarga: DateTime(2025, 7, 16, 8, 54),
+    documento: 'OT-000820.pdf',
+    notas: 'Operación completada sin incidencias.',
+    eventos: [
+      VolqueteEvento(
+        titulo: 'Inicio de maniobra',
+        descripcion: 'Ingreso al chute 4.',
+        fecha: DateTime(2025, 7, 16, 8, 16),
+        icon: VolqueteEventoIcon.arrow,
       ),
       VolqueteEvento(
-        titulo: 'Pausa temporal',
-        descripcion: 'En espera por mantenimiento del frente.',
-        fecha: DateTime(2025, 3, 27, 13, 5),
+        titulo: 'Carga finalizada',
+        descripcion: 'Carga conforme según control de tonelaje.',
+        fecha: DateTime(2025, 7, 16, 8, 54),
+        icon: VolqueteEventoIcon.truckLoaded,
+      ),
+    ],
+    descargas: [
+      VolqueteDescarga(
+        id: 'd108',
+        volquete: '(V01) Volq. SR V3R-770',
+        procedencia: 'Relavado',
+        chute: 4,
+        fechaInicio: DateTime(2025, 7, 10, 6, 0),
+        fechaFin: DateTime(2025, 7, 10, 6, 34),
       ),
     ],
   ),
   Volquete(
     id: 'v11',
-    codigo: '(V11) Volq. JAA X3U-843',
-    placa: 'JAA X3U-843',
-    operador: 'Carlos Velarde',
-    destino: 'Planta de chancado',
-    fecha: DateTime(2025, 3, 27, 16, 10),
-    estado: VolqueteEstado.enProceso,
-    tipo: VolqueteTipo.descarga,
-    equipo: VolqueteEquipo.excavadora,
-    documento: 'OrdenDescarga_V11.pdf',
+    codigo: '(V11) Volq. SR V3R-770',
+    placa: 'SR V3R-770',
+    operador: '(E03) Carg. AD L150F',
+    destino: 'Beatriz 1',
+    fecha: DateTime(2025, 7, 8, 8, 43, 12),
+    estado: VolqueteEstado.incompleto,
+    tipo: VolqueteTipo.carga,
+    equipo: VolqueteEquipo.cargador,
+    maquinaria: '(E03) Carg. AD L150F',
+    procedencias: const ['Beatriz 1', 'Beatriz 3'],
+    chute: 2,
+    llegadaFrente: DateTime(2025, 7, 8, 8, 16),
+    inicioManiobra: DateTime(2025, 7, 8, 8, 20),
+    inicioCarga: DateTime(2025, 7, 8, 8, 32),
+    finCarga: null,
+    documento: 'OT-000799.pdf',
+    notas: 'Coordinar apoyo de mantenimiento.',
     eventos: [
       VolqueteEvento(
-        titulo: 'Ruta asignada',
-        descripcion: 'Excavadora CX-02 designada para descarga.',
-        fecha: DateTime(2025, 3, 27, 15, 50),
-      ),
-      VolqueteEvento(
-        titulo: 'Descarga iniciada',
-        descripcion: 'Inicia maniobra en planta.',
-        fecha: DateTime(2025, 3, 27, 16, 5),
+        titulo: 'Registro creado',
+        descripcion: 'Ingreso manual desde panel de control.',
+        fecha: DateTime(2025, 7, 8, 8, 16),
+        icon: VolqueteEventoIcon.pencil,
       ),
     ],
-  ),
-  Volquete(
-    id: 'v14',
-    codigo: '(V14) Volq. GQ VQN-840',
-    placa: 'GQ VQN-840',
-    operador: 'Ana Espino',
-    destino: 'Depósito temporal B',
-    fecha: DateTime(2025, 3, 27, 11, 30),
-    estado: VolqueteEstado.completo,
-    tipo: VolqueteTipo.descarga,
-    equipo: VolqueteEquipo.excavadora,
-    documento: 'OrdenDescarga_V14.pdf',
-    eventos: [
-      VolqueteEvento(
-        titulo: 'Ingreso a descarga',
-        descripcion: 'Control de acceso completado.',
-        fecha: DateTime(2025, 3, 27, 11, 5),
+    descargas: [
+      VolqueteDescarga(
+        id: 'd109',
+        volquete: '(V11) Volq. SR V3R-770',
+        procedencia: 'Beatriz 1',
+        chute: 2,
+        fechaInicio: DateTime(2025, 7, 6, 9, 20),
+        fechaFin: DateTime(2025, 7, 6, 9, 50),
       ),
-      VolqueteEvento(
-        titulo: 'Descarga completada',
-        descripcion: 'Material dispuesto en depósito temporal.',
-        fecha: DateTime(2025, 3, 27, 11, 25),
-      ),
-    ],
-  ),
-  Volquete(
-    id: 'v20',
-    codigo: '(V20) Volq. RD F7V-760',
-    placa: 'RD F7V-760',
-    operador: 'Luis Ramos',
-    destino: 'Botadero norte',
-    fecha: DateTime(2025, 3, 27, 10, 45),
-    estado: VolqueteEstado.enProceso,
-    tipo: VolqueteTipo.descarga,
-    equipo: VolqueteEquipo.excavadora,
-    documento: 'OrdenDescarga_V20.pdf',
-    eventos: [
-      VolqueteEvento(
-        titulo: 'Salida de planta',
-        descripcion: 'Traslado con guía de transporte 001122.',
-        fecha: DateTime(2025, 3, 27, 10, 20),
-      ),
-      VolqueteEvento(
-        titulo: 'En ruta',
-        descripcion: 'Esperando autorización para descarga.',
-        fecha: DateTime(2025, 3, 27, 10, 40),
+      VolqueteDescarga(
+        id: 'd110',
+        volquete: '(V11) Volq. SR V3R-770',
+        procedencia: 'Beatriz 3',
+        chute: 5,
+        fechaInicio: DateTime(2025, 7, 5, 17, 5),
+        fechaFin: DateTime(2025, 7, 5, 17, 32),
       ),
     ],
   ),

--- a/lib/features/control_tiempos/presentation/pages/volquete_detail_page.dart
+++ b/lib/features/control_tiempos/presentation/pages/volquete_detail_page.dart
@@ -1,220 +1,115 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
 
 import 'package:toolmape/features/control_tiempos/domain/entities/volquete.dart';
 import 'package:toolmape/features/control_tiempos/presentation/pages/volquete_form_page.dart';
+import 'package:toolmape/features/control_tiempos/presentation/theme/control_tiempos_palette.dart';
 
-class VolqueteDetailPage extends StatelessWidget {
-  VolqueteDetailPage({
+const String _iconArrowRight = 'assets/icons/arrow_right.svg';
+const String _iconTruckEmpty = 'assets/icons/truck_small.svg';
+const String _iconTruckLoaded = 'assets/icons/truck_large.svg';
+
+class VolqueteDetailPage extends StatefulWidget {
+  const VolqueteDetailPage({
     super.key,
     required this.volquete,
-  }) : _dateFormat = DateFormat('dd/MM/yyyy – HH:mm');
-
-  final Volquete volquete;
-  final DateFormat _dateFormat;
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(volquete.codigo),
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _HeaderSection(volquete: volquete, dateFormat: _dateFormat),
-              const SizedBox(height: 24),
-              _TimelineSection(volquete: volquete, dateFormat: _dateFormat),
-              const SizedBox(height: 24),
-              _ActionsSection(volquete: volquete),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _HeaderSection extends StatelessWidget {
-  const _HeaderSection({
-    required this.volquete,
-    required this.dateFormat,
   });
 
   final Volquete volquete;
-  final DateFormat dateFormat;
 
   @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Card(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              volquete.codigo,
-              style: theme.textTheme.titleLarge,
-            ),
-            const SizedBox(height: 12),
-            Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [
-                _InfoChip(
-                  icon: Icons.badge_outlined,
-                  label: 'Operador',
-                  value: volquete.operador,
-                ),
-                _InfoChip(
-                  icon: Icons.tag_outlined,
-                  label: 'Placa',
-                  value: volquete.placa,
-                ),
-                _InfoChip(
-                  icon: Icons.route_outlined,
-                  label: 'Destino',
-                  value: volquete.destino,
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            Row(
-              children: [
-                _StatusIndicator(estado: volquete.estado),
-                const SizedBox(width: 16),
-                Text(
-                  dateFormat.format(volquete.fecha),
-                  style: theme.textTheme.bodyMedium,
-                ),
-              ],
-            ),
-            if (volquete.notas != null && volquete.notas!.isNotEmpty) ...[
-              const SizedBox(height: 16),
-              Text(
-                volquete.notas!,
-                style: theme.textTheme.bodyMedium,
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
+  State<VolqueteDetailPage> createState() => _VolqueteDetailPageState();
 }
 
-class _TimelineSection extends StatelessWidget {
-  const _TimelineSection({
-    required this.volquete,
-    required this.dateFormat,
-  });
-
-  final Volquete volquete;
-  final DateFormat dateFormat;
+class _VolqueteDetailPageState extends State<VolqueteDetailPage>
+    with SingleTickerProviderStateMixin {
+  late Volquete _volquete;
+  late final TabController _tabController;
+  late final DateFormat _dateFormat;
+  Volquete? _createdVolquete;
 
   @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'Línea de tiempo',
-          style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
-        ),
-        const SizedBox(height: 12),
-        ListView.separated(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          itemCount: volquete.eventos.length,
-          separatorBuilder: (_, __) => const Divider(height: 24),
-          itemBuilder: (_, index) {
-            final evento = volquete.eventos[index];
-            return Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Column(
-                  children: [
-                    Container(
-                      width: 12,
-                      height: 12,
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.primary,
-                        shape: BoxShape.circle,
-                      ),
-                    ),
-                    if (index != volquete.eventos.length - 1)
-                      Container(
-                        width: 2,
-                        height: 48,
-                        margin: const EdgeInsets.symmetric(vertical: 4),
-                        color: Theme.of(context).colorScheme.primary.withOpacity(0.3),
-                      ),
-                  ],
-                ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        evento.titulo,
-                        style: theme.textTheme.titleSmall,
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        dateFormat.format(evento.fecha),
-                        style: theme.textTheme.bodySmall
-                            ?.copyWith(color: Colors.grey.shade600),
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        evento.descripcion,
-                        style: theme.textTheme.bodyMedium,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            );
-          },
-        ),
-      ],
-    );
+  void initState() {
+    super.initState();
+    _volquete = widget.volquete;
+    _tabController = TabController(length: 2, vsync: this);
+    _dateFormat = DateFormat('dd/MM/yyyy – HH:mm');
   }
-}
 
-class _ActionsSection extends StatelessWidget {
-  const _ActionsSection({required this.volquete});
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
 
-  final Volquete volquete;
-
-  Future<void> _onEditar(BuildContext context) async {
+  Future<void> _editVolquete() async {
     final updated = await Navigator.push<Volquete>(
       context,
       MaterialPageRoute(
-        builder: (_) => VolqueteFormPage(initial: volquete),
+        builder: (_) => VolqueteFormPage(
+          initial: _volquete,
+          defaultTipo: _volquete.tipo,
+          defaultEquipo: _volquete.equipo,
+          mode: VolqueteFormMode.edit,
+        ),
       ),
     );
 
     if (updated == null) return;
-    Navigator.pop(
-      context,
-      VolqueteDetailResult(updatedVolquete: updated),
+
+    setState(() {
+      _volquete = updated;
+    });
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Registro actualizado.')),
     );
   }
 
-  Future<void> _onEliminar(BuildContext context) async {
+  Future<void> _openQuickAdd() async {
+    final created = await Navigator.push<Volquete>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => VolqueteFormPage(
+          defaultTipo: _volquete.tipo,
+          defaultEquipo: _volquete.equipo,
+          mode: VolqueteFormMode.quickAdd,
+        ),
+      ),
+    );
+
+    if (created == null) return;
+
+    final VolqueteDescarga newDescarga = VolqueteDescarga(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      volquete: created.codigo,
+      procedencia: created.procedencias.join(' / '),
+      chute: created.chute,
+      fechaInicio: created.inicioManiobra ?? created.llegadaFrente,
+      fechaFin: created.finCarga ?? created.llegadaFrente.add(const Duration(minutes: 45)),
+    );
+
+    setState(() {
+      _volquete = _volquete.copyWith(
+        descargas: [newDescarga, ..._volquete.descargas],
+      );
+      _createdVolquete = created;
+    });
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Nueva carga registrada desde el detalle.')),
+    );
+  }
+
+  Future<void> _confirmDelete() async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (_) => AlertDialog(
-        title: const Text('Eliminar volquete'),
-        content: const Text('¿Deseas eliminar el registro seleccionado?'),
+        title: const Text('Eliminar registro'),
+        content: const Text('¿Deseas eliminar esta carga?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -222,6 +117,10 @@ class _ActionsSection extends StatelessWidget {
           ),
           FilledButton(
             onPressed: () => Navigator.pop(context, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+              foregroundColor: Theme.of(context).colorScheme.onError,
+            ),
             child: const Text('Eliminar'),
           ),
         ],
@@ -229,99 +128,310 @@ class _ActionsSection extends StatelessWidget {
     );
 
     if (confirmed == true) {
-      Navigator.pop(
-        context,
-        VolqueteDetailResult(deletedVolqueteId: volquete.id),
-      );
+      _popWithResult(deleted: true);
     }
   }
 
-  void _onCompartir(BuildContext context) {
+  void _registerInicioManiobra() {
+    setState(() {
+      _volquete = _volquete.copyWith(
+        inicioManiobra: DateTime.now(),
+        eventos: [
+          ..._volquete.eventos,
+          VolqueteEvento(
+            titulo: 'Inicio de maniobra',
+            descripcion: 'Actualizado manualmente desde el panel.',
+            fecha: DateTime.now(),
+            icon: VolqueteEventoIcon.arrow,
+          ),
+        ],
+      );
+    });
+    _showSnack('Inicio de maniobra registrado.');
+  }
+
+  void _registerInicioCarga() {
+    setState(() {
+      _volquete = _volquete.copyWith(
+        inicioCarga: DateTime.now(),
+        eventos: [
+          ..._volquete.eventos,
+          VolqueteEvento(
+            titulo: 'Inicio de carga',
+            descripcion: 'Marcado por supervisor.',
+            fecha: DateTime.now(),
+            icon: VolqueteEventoIcon.truckEmpty,
+          ),
+        ],
+      );
+    });
+    _showSnack('Inicio de carga registrado.');
+  }
+
+  void _registerFinCarga() {
+    setState(() {
+      _volquete = _volquete.copyWith(
+        finCarga: DateTime.now(),
+        estado: VolqueteEstado.completo,
+        eventos: [
+          ..._volquete.eventos,
+          VolqueteEvento(
+            titulo: 'Fin de carga',
+            descripcion: 'Carga confirmada desde módulo de control.',
+            fecha: DateTime.now(),
+            icon: VolqueteEventoIcon.truckLoaded,
+          ),
+        ],
+      );
+    });
+    _showSnack('Carga finalizada.');
+  }
+
+  void _showSnack(String message) {
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Enlace compartido en portapapeles.')),
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  Future<bool> _onWillPop() async {
+    _popWithResult();
+    return false;
+  }
+
+  void _popWithResult({bool deleted = false}) {
+    Navigator.pop(
+      context,
+      VolqueteDetailResult(
+        updatedVolquete: deleted ? null : _volquete,
+        deletedVolqueteId: deleted ? _volquete.id : null,
+        createdVolquete: _createdVolquete,
+      ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          'Acciones',
-          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-        ),
-        const SizedBox(height: 12),
-        Wrap(
-          spacing: 12,
-          runSpacing: 12,
-          children: [
-            FilledButton.icon(
-              onPressed: () => _onEditar(context),
-              icon: const Icon(Icons.edit_outlined),
-              label: const Text('Editar'),
+    final theme = Theme.of(context);
+    final palette = ControlTiemposPalette.of(theme);
+    final textTheme = theme.textTheme;
+
+    return WillPopScope(
+      onWillPop: _onWillPop,
+      child: Scaffold(
+        backgroundColor: palette.background,
+        appBar: AppBar(
+          backgroundColor: palette.background,
+          foregroundColor: palette.primaryText,
+          iconTheme: IconThemeData(color: palette.icon),
+          actionsIconTheme: IconThemeData(color: palette.icon),
+          title: Text(_volquete.codigo),
+          actions: [
+            IconButton(
+              onPressed: _editVolquete,
+              tooltip: 'Editar registro',
+              icon: Icon(Icons.edit_outlined, color: palette.icon),
             ),
-            OutlinedButton.icon(
-              onPressed: () => _onEliminar(context),
-              icon: const Icon(Icons.delete_outline),
-              label: const Text('Eliminar'),
-            ),
-            OutlinedButton.icon(
-              onPressed: () => _onCompartir(context),
-              icon: const Icon(Icons.ios_share_outlined),
-              label: const Text('Compartir'),
+            IconButton(
+              onPressed: _confirmDelete,
+              tooltip: 'Eliminar',
+              icon: Icon(Icons.delete_outline, color: palette.icon),
             ),
           ],
         ),
-      ],
+        floatingActionButton: FloatingActionButton(
+          backgroundColor: palette.accent,
+          foregroundColor: palette.onAccent,
+          onPressed: _openQuickAdd,
+          child: const Icon(Icons.add),
+        ),
+        body: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              _volquete.maquinaria,
+                              style: textTheme.titleLarge?.copyWith(
+                                    fontWeight: FontWeight.w700,
+                                    color: palette.primaryText,
+                                  ),
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              'Procedencia: ${_volquete.procedencias.join(' / ')}',
+                              style: textTheme.bodyMedium?.copyWith(
+                                color: palette.mutedText,
+                              ),
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              'Chute ${_volquete.chute} • ${_dateFormat.format(_volquete.llegadaFrente)}',
+                              style: textTheme.bodySmall?.copyWith(
+                                color: palette.subtleText,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      _StatusPill(estado: _volquete.estado),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _PrimaryActionButton(
+                          label: 'Inicio maniobra',
+                          iconBuilder: (palette) => SvgPicture.asset(
+                            _iconArrowRight,
+                            width: 32,
+                            height: 32,
+                            colorFilter:
+                                ColorFilter.mode(palette.icon, BlendMode.srcIn),
+                          ),
+                          onPressed: _registerInicioManiobra,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: _PrimaryActionButton(
+                          label: 'Inicio carga',
+                          iconBuilder: (palette) => SvgPicture.asset(
+                            _iconTruckEmpty,
+                            width: 32,
+                            height: 32,
+                            colorFilter:
+                                ColorFilter.mode(palette.icon, BlendMode.srcIn),
+                          ),
+                          onPressed: _registerInicioCarga,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: _PrimaryActionButton(
+                          label: 'Final carga',
+                          iconBuilder: (palette) => SvgPicture.asset(
+                            _iconTruckLoaded,
+                            width: 32,
+                            height: 32,
+                            colorFilter: ColorFilter.mode(
+                                palette.onAccent, BlendMode.srcIn),
+                          ),
+                          onPressed: _registerFinCarga,
+                          backgroundColor: palette.accent,
+                          foregroundColor: palette.onAccent,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: Container(
+                margin: const EdgeInsets.symmetric(horizontal: 16),
+                decoration: BoxDecoration(
+                  color: palette.surface,
+                  borderRadius: BorderRadius.circular(24),
+                ),
+                child: Column(
+                  children: [
+                    TabBar(
+                      controller: _tabController,
+                      indicator: BoxDecoration(
+                        color: palette.accent,
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      indicatorSize: TabBarIndicatorSize.tab,
+                      labelColor: palette.onAccent,
+                      unselectedLabelColor: palette.mutedText,
+                      tabs: const [
+                        Tab(text: 'Carga'),
+                        Tab(text: 'Descargas'),
+                      ],
+                    ),
+                    Expanded(
+                      child: TabBarView(
+                        controller: _tabController,
+                        children: [
+                          _CargaTab(
+                            volquete: _volquete,
+                            dateFormat: _dateFormat,
+                          ),
+                          _DescargasTab(
+                            volquete: _volquete,
+                            dateFormat: _dateFormat,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
 
-class _StatusIndicator extends StatelessWidget {
-  const _StatusIndicator({required this.estado});
+class _PrimaryActionButton extends StatelessWidget {
+  const _PrimaryActionButton({
+    required this.label,
+    required this.iconBuilder,
+    required this.onPressed,
+    this.backgroundColor,
+    this.foregroundColor,
+  });
 
-  final VolqueteEstado estado;
-
-  Color _color(BuildContext context) {
-    switch (estado) {
-      case VolqueteEstado.completo:
-        return Colors.green.shade600;
-      case VolqueteEstado.enProceso:
-        return Colors.orange.shade600;
-      case VolqueteEstado.pausado:
-        return Colors.blueGrey.shade600;
-    }
-  }
+  final String label;
+  final Widget Function(ControlTiemposPalette palette) iconBuilder;
+  final VoidCallback onPressed;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(999),
-        color: _color(context).withOpacity(0.15),
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    final Color bg = backgroundColor ?? palette.surface;
+    final Color fg = foregroundColor ?? palette.primaryText;
+
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: bg,
+        foregroundColor: fg,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       ),
-      child: Row(
+      child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
-            width: 8,
-            height: 8,
-            decoration: BoxDecoration(
-              color: _color(context),
-              shape: BoxShape.circle,
-            ),
+          SizedBox(
+            height: 40,
+            child: Center(child: iconBuilder(palette)),
           ),
-          const SizedBox(width: 8),
+          const SizedBox(height: 12),
           Text(
-            estado.label,
-            style: Theme.of(context)
-                .textTheme
-                .labelMedium
-                ?.copyWith(color: _color(context), fontWeight: FontWeight.bold),
+            label.toUpperCase(),
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  letterSpacing: 0.4,
+                  color: fg,
+                ),
           ),
         ],
       ),
@@ -329,44 +439,422 @@ class _StatusIndicator extends StatelessWidget {
   }
 }
 
-class _InfoChip extends StatelessWidget {
-  const _InfoChip({
-    required this.icon,
-    required this.label,
-    required this.value,
-  });
+class _CargaTab extends StatelessWidget {
+  const _CargaTab({required this.volquete, required this.dateFormat});
 
-  final IconData icon;
+  final Volquete volquete;
+  final DateFormat dateFormat;
+
+  String _format(DateTime? date) {
+    if (date == null) return '—';
+    return dateFormat.format(date);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(20),
+      children: [
+        _DetailRow(label: 'Volquete', value: volquete.codigo),
+        _DetailRow(label: 'Maquinaria', value: volquete.maquinaria),
+        _DetailRow(
+          label: 'Procedencia',
+          value: volquete.procedencias.join(' / '),
+        ),
+        _DetailRow(label: 'Chute', value: 'Chute ${volquete.chute}'),
+        _DetailRow(
+          label: 'Llegada a frente',
+          value: dateFormat.format(volquete.llegadaFrente),
+        ),
+        _DetailRow(
+          label: 'Inicio maniobra',
+          value: _format(volquete.inicioManiobra),
+        ),
+        _DetailRow(
+          label: 'Inicio carga',
+          value: _format(volquete.inicioCarga),
+        ),
+        _DetailRow(
+          label: 'Fin carga',
+          value: _format(volquete.finCarga),
+        ),
+        const SizedBox(height: 12),
+        if (volquete.notas != null && volquete.notas!.isNotEmpty)
+          _DetailRow(label: 'Observaciones', value: volquete.notas!),
+        const SizedBox(height: 24),
+        Text(
+          'Descargas relacionadas',
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+        const SizedBox(height: 12),
+        _DescargasTable(volquete: volquete, dateFormat: dateFormat),
+        const SizedBox(height: 24),
+        if (volquete.eventos.isNotEmpty) ...[
+          Text(
+            'Línea de tiempo',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 12),
+          ...volquete.eventos.map(
+            (evento) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: _TimelineTile(evento: evento, dateFormat: dateFormat),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _DescargasTab extends StatelessWidget {
+  const _DescargasTab({required this.volquete, required this.dateFormat});
+
+  final Volquete volquete;
+  final DateFormat dateFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+
+    if (volquete.descargas.isEmpty) {
+      return Center(
+        child: Text(
+          'Sin descargas registradas',
+          style: Theme.of(context)
+              .textTheme
+              .bodyMedium
+              ?.copyWith(color: palette.mutedText),
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.all(20),
+      itemCount: volquete.descargas.length,
+      itemBuilder: (_, index) {
+        final descarga = volquete.descargas[index];
+        return Container(
+          margin: const EdgeInsets.only(bottom: 12),
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: palette.surface,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: palette.outline.withOpacity(0.4)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                descarga.volquete,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: palette.primaryText,
+                    ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                'Procedencia: ${descarga.procedencia}',
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyMedium
+                    ?.copyWith(color: palette.mutedText),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Chute ${descarga.chute}',
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: palette.subtleText),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '${dateFormat.format(descarga.fechaInicio)} – ${dateFormat.format(descarga.fechaFin)}',
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: palette.subtleText),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DescargasTable extends StatelessWidget {
+  const _DescargasTable({required this.volquete, required this.dateFormat});
+
+  final Volquete volquete;
+  final DateFormat dateFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    if (volquete.descargas.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: palette.surface,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Text(
+          'No existen descargas vinculadas a este registro.',
+          style: Theme.of(context)
+              .textTheme
+              .bodyMedium
+              ?.copyWith(color: palette.mutedText),
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        headingRowColor:
+            WidgetStatePropertyAll(palette.surface.withOpacity(0.4)),
+        columnSpacing: 28,
+        columns: [
+          DataColumn(label: Text('Volquete', style: TextStyle(color: palette.mutedText))),
+          DataColumn(label: Text('Procedencia', style: TextStyle(color: palette.mutedText))),
+          DataColumn(label: Text('Chute', style: TextStyle(color: palette.mutedText))),
+          DataColumn(label: Text('Fechas', style: TextStyle(color: palette.mutedText))),
+        ],
+        rows: volquete.descargas
+            .map(
+              (descarga) => DataRow(
+                cells: [
+                  DataCell(Text(descarga.volquete,
+                      style: TextStyle(color: palette.primaryText))),
+                  DataCell(Text(descarga.procedencia,
+                      style: TextStyle(color: palette.primaryText))),
+                  DataCell(Text(descarga.chute.toString(),
+                      style: TextStyle(color: palette.primaryText))),
+                  DataCell(
+                    Text(
+                      '${dateFormat.format(descarga.fechaInicio)}\n${dateFormat.format(descarga.fechaFin)}',
+                      style: TextStyle(color: palette.subtleText),
+                    ),
+                  ),
+                ],
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.label, required this.value});
+
   final String label;
   final String value;
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: palette.subtleText,
+                  letterSpacing: 0.6,
+                ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: Theme.of(context)
+                .textTheme
+                .bodyLarge
+                ?.copyWith(color: palette.primaryText),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimelineTile extends StatelessWidget {
+  const _TimelineTile({required this.evento, required this.dateFormat});
+
+  final VolqueteEvento evento;
+  final DateFormat dateFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _TimelineIcon(icon: evento.icon),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                evento.titulo,
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: palette.primaryText,
+                    ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                dateFormat.format(evento.fecha),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: palette.subtleText,
+                      fontSize: 12,
+                    ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                evento.descripcion,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyMedium
+                    ?.copyWith(color: palette.mutedText),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TimelineIcon extends StatelessWidget {
+  const _TimelineIcon({required this.icon});
+
+  final VolqueteEventoIcon icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    final String? asset = icon.assetPath;
+    final String? emoji = icon.emojiSymbol;
+
+    if (asset != null || (emoji != null && emoji.isNotEmpty)) {
+      return Container(
+        margin: const EdgeInsets.only(top: 4),
+        width: 40,
+        height: 40,
+        decoration: BoxDecoration(
+          color: palette.surface.withOpacity(0.4),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: palette.outline.withOpacity(0.6)),
+        ),
+        alignment: Alignment.center,
+        child: asset != null
+            ? SvgPicture.asset(
+                asset,
+                colorFilter:
+                    ColorFilter.mode(palette.icon, BlendMode.srcIn),
+              )
+            : Text(
+                emoji!,
+                style: TextStyle(
+                  fontSize: 20,
+                  color: palette.icon,
+                ),
+              ),
+      );
+    }
+
     return Container(
-      padding: const EdgeInsets.all(12),
+      margin: const EdgeInsets.only(top: 6),
+      width: 12,
+      height: 12,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(12),
-        color: theme.colorScheme.surfaceVariant,
+        shape: BoxShape.circle,
+        color: palette.accent,
+      ),
+    );
+  }
+}
+
+extension on VolqueteEventoIcon {
+  String? get assetPath {
+    switch (this) {
+      case VolqueteEventoIcon.arrow:
+        return 'assets/icons/arrow_right.svg';
+      case VolqueteEventoIcon.truckEmpty:
+        return 'assets/icons/truck_small.svg';
+      case VolqueteEventoIcon.truckLoaded:
+        return 'assets/icons/truck_large.svg';
+      case VolqueteEventoIcon.pencil:
+        return 'assets/icons/edit_pen.svg';
+      case VolqueteEventoIcon.clock:
+      case VolqueteEventoIcon.generic:
+        return null;
+    }
+  }
+
+  String? get emojiSymbol {
+    switch (this) {
+      case VolqueteEventoIcon.arrow:
+        return '→';
+      case VolqueteEventoIcon.truckEmpty:
+        return '🚚';
+      case VolqueteEventoIcon.truckLoaded:
+        return '🚛';
+      case VolqueteEventoIcon.clock:
+        return '⏱️';
+      case VolqueteEventoIcon.pencil:
+        return '✏️';
+      case VolqueteEventoIcon.generic:
+        return null;
+    }
+  }
+}
+
+class _StatusPill extends StatelessWidget {
+  const _StatusPill({required this.estado});
+
+  final VolqueteEstado estado;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    final bool completo = estado == VolqueteEstado.completo;
+    final Color color = completo ? palette.success : palette.accent;
+    final Color background = color.withOpacity(completo ? 0.15 : 0.2);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withOpacity(0.45)),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(icon, size: 20, color: theme.colorScheme.primary),
+          Container(
+            width: 10,
+            height: 10,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+            ),
+          ),
           const SizedBox(width: 8),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                label,
-                style: theme.textTheme.labelSmall
-                    ?.copyWith(color: theme.colorScheme.primary),
-              ),
-              Text(
-                value,
-                style: theme.textTheme.bodyMedium,
-              ),
-            ],
+          Text(
+            estado.label,
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.bold,
+                ),
           ),
         ],
       ),
@@ -378,8 +866,10 @@ class VolqueteDetailResult {
   const VolqueteDetailResult({
     this.updatedVolquete,
     this.deletedVolqueteId,
+    this.createdVolquete,
   });
 
   final Volquete? updatedVolquete;
   final String? deletedVolqueteId;
+  final Volquete? createdVolquete;
 }

--- a/lib/features/control_tiempos/presentation/pages/volquete_form_page.dart
+++ b/lib/features/control_tiempos/presentation/pages/volquete_form_page.dart
@@ -1,7 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
 
 import 'package:toolmape/features/control_tiempos/domain/entities/volquete.dart';
+import 'package:toolmape/features/control_tiempos/presentation/theme/control_tiempos_palette.dart';
+
+const String _iconArrowRight = 'assets/icons/arrow_right.svg';
+const String _iconTruckEmpty = 'assets/icons/truck_small.svg';
+const String _iconTruckLoaded = 'assets/icons/truck_large.svg';
+const String _iconEditPen = 'assets/icons/edit_pen.svg';
+
+const List<String> _procedenciaOptions = [
+  'Beatriz 1',
+  'Beatriz 2',
+  'Beatriz 3',
+  'Panchita 1',
+  'Panchita 2',
+  'Relavado',
+];
+
+const List<String> _maquinariaOptions = [
+  '(E01) Excav. C 340-01',
+  '(E02) Excav. ZX 350',
+  '(E03) Carg. AD L150F',
+  '(E04) Carg. WA600',
+];
+
+enum VolqueteFormMode { create, edit, quickAdd }
 
 class VolqueteFormPage extends StatefulWidget {
   const VolqueteFormPage({
@@ -9,11 +34,13 @@ class VolqueteFormPage extends StatefulWidget {
     this.initial,
     this.defaultTipo,
     this.defaultEquipo,
+    this.mode = VolqueteFormMode.create,
   });
 
   final Volquete? initial;
   final VolqueteTipo? defaultTipo;
   final VolqueteEquipo? defaultEquipo;
+  final VolqueteFormMode mode;
 
   @override
   State<VolqueteFormPage> createState() => _VolqueteFormPageState();
@@ -21,256 +48,492 @@ class VolqueteFormPage extends StatefulWidget {
 
 class _VolqueteFormPageState extends State<VolqueteFormPage> {
   final _formKey = GlobalKey<FormState>();
-  late final TextEditingController _codigoController;
-  late final TextEditingController _placaController;
-  late final TextEditingController _operadorController;
-  late final TextEditingController _destinoController;
-  late final TextEditingController _notasController;
+  late final TextEditingController _volqueteController;
+  late final TextEditingController _observacionesController;
   late final TextEditingController _fechaController;
-  late DateTime _fecha;
+  late DateTime _llegadaFrente;
+  late Set<String> _procedencias;
+  late int _selectedChute;
   late VolqueteEstado _estado;
   late VolqueteTipo _tipo;
   late VolqueteEquipo _equipo;
-
+  late String _maquinaria;
+  late List<String> _availableMaquinarias;
   final DateFormat _dateFormat = DateFormat('dd/MM/yyyy – HH:mm');
 
   @override
   void initState() {
     super.initState();
     final initial = widget.initial;
-    _codigoController = TextEditingController(text: initial?.codigo ?? '');
-    _placaController = TextEditingController(text: initial?.placa ?? '');
-    _operadorController = TextEditingController(text: initial?.operador ?? '');
-    _destinoController = TextEditingController(text: initial?.destino ?? '');
-    _notasController = TextEditingController(text: initial?.notas ?? '');
-    _fecha = initial?.fecha ?? DateTime.now();
-    _estado = initial?.estado ?? VolqueteEstado.enProceso;
+    _volqueteController = TextEditingController(text: initial?.codigo ?? '');
+    _observacionesController =
+        TextEditingController(text: initial?.notas ?? '');
+    _llegadaFrente = initial?.llegadaFrente ?? DateTime.now();
+    _procedencias = initial != null
+        ? initial.procedencias.toSet()
+        : {_procedenciaOptions.first};
+    _selectedChute = initial?.chute ?? 1;
+    _estado = initial?.estado ?? VolqueteEstado.incompleto;
     _tipo = initial?.tipo ?? widget.defaultTipo ?? VolqueteTipo.carga;
     _equipo = initial?.equipo ?? widget.defaultEquipo ?? VolqueteEquipo.cargador;
-    _fechaController =
-        TextEditingController(text: _dateFormat.format(_fecha));
+    _availableMaquinarias = List<String>.from(_maquinariaOptions);
+    _maquinaria = initial?.maquinaria ?? _availableMaquinarias.first;
+    if (!_availableMaquinarias.contains(_maquinaria)) {
+      _availableMaquinarias.insert(0, _maquinaria);
+    }
+    _fechaController = TextEditingController(text: _dateFormat.format(_llegadaFrente));
   }
 
   @override
   void dispose() {
-    _codigoController.dispose();
-    _placaController.dispose();
-    _operadorController.dispose();
-    _destinoController.dispose();
-    _notasController.dispose();
+    _volqueteController.dispose();
+    _observacionesController.dispose();
     _fechaController.dispose();
     super.dispose();
   }
 
   Future<void> _selectFecha() async {
-    final initialDate = _fecha;
     final pickedDate = await showDatePicker(
       context: context,
-      firstDate: DateTime(2020),
+      initialDate: _llegadaFrente,
+      firstDate: DateTime(2024),
       lastDate: DateTime(2030),
-      initialDate: initialDate,
     );
-
     if (pickedDate == null) return;
 
     final pickedTime = await showTimePicker(
       context: context,
-      initialTime: TimeOfDay.fromDateTime(initialDate),
+      initialTime: TimeOfDay.fromDateTime(_llegadaFrente),
     );
-
     if (pickedTime == null) return;
 
     setState(() {
-      _fecha = DateTime(
+      _llegadaFrente = DateTime(
         pickedDate.year,
         pickedDate.month,
         pickedDate.day,
         pickedTime.hour,
         pickedTime.minute,
       );
-      _fechaController.text = _dateFormat.format(_fecha);
+      _fechaController.text = _dateFormat.format(_llegadaFrente);
     });
   }
 
   void _submit() {
     if (!_formKey.currentState!.validate()) return;
 
+    final observaciones = _observacionesController.text.trim();
     final eventos = widget.initial?.eventos ??
         [
           VolqueteEvento(
             titulo: 'Registro creado',
-            descripcion: 'Ingreso manual desde el panel de control.',
+            descripcion: 'Ingreso desde módulo Control de Tiempos.',
             fecha: DateTime.now(),
           ),
         ];
 
     final volquete = Volquete(
       id: widget.initial?.id ?? DateTime.now().millisecondsSinceEpoch.toString(),
-      codigo: _codigoController.text.trim(),
-      placa: _placaController.text.trim(),
-      operador: _operadorController.text.trim(),
-      destino: _destinoController.text.trim(),
-      fecha: _fecha,
+      codigo: _volqueteController.text.trim(),
+      placa: widget.initial?.placa ?? '-',
+      operador: _maquinaria,
+      destino: _procedencias.isEmpty ? '-' : _procedencias.first,
+      fecha: _llegadaFrente,
       estado: _estado,
       tipo: _tipo,
       equipo: _equipo,
-      notas: _notasController.text.trim().isEmpty
-          ? widget.initial?.notas
-          : _notasController.text.trim(),
-      documento: widget.initial?.documento,
       eventos: eventos,
+      maquinaria: _maquinaria,
+      procedencias: _procedencias.toList(),
+      chute: _selectedChute,
+      llegadaFrente: _llegadaFrente,
+      inicioManiobra: widget.initial?.inicioManiobra,
+      inicioCarga: widget.initial?.inicioCarga,
+      finCarga: widget.initial?.finCarga,
+      descargas: widget.initial?.descargas ?? const <VolqueteDescarga>[],
+      documento: widget.initial?.documento,
+      notas: observaciones.isEmpty ? widget.initial?.notas : observaciones,
     );
 
     Navigator.pop(context, volquete);
   }
 
+  void _cancel() {
+    Navigator.pop(context);
+  }
+
   @override
   Widget build(BuildContext context) {
-    final isEditing = widget.initial != null;
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(isEditing ? 'Editar volquete' : 'Registrar volquete'),
-        actions: [
-          TextButton(
-            onPressed: _submit,
-            child: const Text('Guardar'),
-          ),
-        ],
+    final ThemeData baseTheme = Theme.of(context);
+    final ControlTiemposPalette palette = ControlTiemposPalette.of(baseTheme);
+    final ThemeData themed = baseTheme.copyWith(
+      scaffoldBackgroundColor: palette.background,
+      colorScheme: baseTheme.colorScheme.copyWith(
+        primary: palette.accent,
+        secondary: palette.accent,
+        surface: palette.surface,
+        background: palette.background,
+        onSurface: palette.primaryText,
+        onPrimary: palette.onAccent,
       ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: Form(
-            key: _formKey,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                TextFormField(
-                  controller: _codigoController,
-                  decoration: const InputDecoration(
-                    labelText: 'Código / Alias',
-                    hintText: '(V01) Volq. ABC-123',
-                  ),
-                  validator: (value) {
-                    if (value == null || value.trim().isEmpty) {
-                      return 'Ingresa un código';
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: _placaController,
-                  decoration: const InputDecoration(
-                    labelText: 'Placa',
-                    hintText: 'ABC-123',
-                  ),
-                  validator: (value) {
-                    if (value == null || value.trim().isEmpty) {
-                      return 'Ingresa la placa';
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: _operadorController,
-                  decoration: const InputDecoration(
-                    labelText: 'Operador',
-                  ),
-                  validator: (value) {
-                    if (value == null || value.trim().isEmpty) {
-                      return 'Ingresa el operador';
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: _destinoController,
-                  decoration: const InputDecoration(
-                    labelText: 'Destino',
-                  ),
-                  validator: (value) {
-                    if (value == null || value.trim().isEmpty) {
-                      return 'Ingresa el destino';
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: _fechaController,
-                  readOnly: true,
-                  onTap: _selectFecha,
-                  decoration: InputDecoration(
-                    labelText: 'Fecha y hora',
-                    hintText: _dateFormat.format(DateTime.now()),
-                    suffixIcon: const Icon(Icons.event_outlined),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                DropdownButtonFormField<VolqueteEstado>(
-                  value: _estado,
-                  decoration: const InputDecoration(labelText: 'Estado'),
-                  items: VolqueteEstado.values
-                      .map(
-                        (estado) => DropdownMenuItem(
-                          value: estado,
-                          child: Text(estado.label),
+      textTheme: baseTheme.textTheme.apply(
+        bodyColor: palette.primaryText,
+        displayColor: palette.primaryText,
+      ),
+      appBarTheme: baseTheme.appBarTheme.copyWith(
+        backgroundColor: palette.background,
+        foregroundColor: palette.primaryText,
+      ),
+      inputDecorationTheme: baseTheme.inputDecorationTheme.copyWith(
+        filled: true,
+        fillColor: palette.surface,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide(color: palette.outline.withOpacity(0.4)),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide(color: palette.outline.withOpacity(0.4)),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide(color: palette.accent, width: 2),
+        ),
+        labelStyle: TextStyle(color: palette.mutedText),
+        hintStyle: TextStyle(color: palette.subtleText),
+      ),
+    );
+
+    final isEditing = widget.mode == VolqueteFormMode.edit;
+    final isQuickAdd = widget.mode == VolqueteFormMode.quickAdd;
+
+    return Theme(
+      data: themed,
+      child: Scaffold(
+        backgroundColor: palette.background,
+        appBar: AppBar(
+          title: Text(isEditing
+              ? 'Editar carga'
+              : isQuickAdd
+                  ? 'Nueva carga rápida'
+                  : 'Añadir nueva carga'),
+        ),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (isQuickAdd) ...[
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _EstadoChip(estado: _estado),
+                        const SizedBox(height: 16),
+                        const Wrap(
+                          spacing: 12,
+                          children: [
+                            _QuickIcon(asset: _iconArrowRight),
+                            _QuickIcon(asset: _iconTruckEmpty),
+                            _QuickIcon(asset: _iconTruckLoaded),
+                            _QuickIcon(asset: _iconEditPen),
+                          ],
                         ),
-                      )
-                      .toList(),
-                  onChanged: (value) {
-                    if (value == null) return;
-                    setState(() => _estado = value);
-                  },
-                ),
-                const SizedBox(height: 16),
-                DropdownButtonFormField<VolqueteTipo>(
-                  value: _tipo,
-                  decoration: const InputDecoration(labelText: 'Tipo'),
-                  items: VolqueteTipo.values
-                      .map(
-                        (tipo) => DropdownMenuItem(
-                          value: tipo,
-                          child: Text(tipo.label),
-                        ),
-                      )
-                      .toList(),
-                  onChanged: (value) {
-                    if (value == null) return;
-                    setState(() => _tipo = value);
-                  },
-                ),
-                const SizedBox(height: 16),
-                DropdownButtonFormField<VolqueteEquipo>(
-                  value: _equipo,
-                  decoration: const InputDecoration(labelText: 'Equipo'),
-                  items: VolqueteEquipo.values
-                      .map(
-                        (equipo) => DropdownMenuItem(
-                          value: equipo,
-                          child: Text(equipo.label),
-                        ),
-                      )
-                      .toList(),
-                  onChanged: (value) {
-                    if (value == null) return;
-                    setState(() => _equipo = value);
-                  },
-                ),
-                const SizedBox(height: 16),
-                TextFormField(
-                  controller: _notasController,
-                  maxLines: 3,
-                  decoration: const InputDecoration(
-                    labelText: 'Notas (opcional)',
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+                  ],
+                  TextFormField(
+                    controller: _volqueteController,
+                    style: TextStyle(color: palette.primaryText),
+                    decoration: const InputDecoration(
+                      labelText: 'Volquete *',
+                      hintText: '(V12) Volq. ABC-123',
+                    ),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Ingresa el nombre del volquete';
+                      }
+                      return null;
+                    },
                   ),
-                ),
-              ],
+                  const SizedBox(height: 16),
+                  DropdownButtonFormField<String>(
+                    value: _maquinaria,
+                    dropdownColor: palette.surface,
+                    decoration: const InputDecoration(
+                      labelText: 'Maquinaria',
+                    ),
+                    items: _availableMaquinarias
+                        .map(
+                          (item) => DropdownMenuItem<String>(
+                            value: item,
+                            child: Text(item),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (value) {
+                      if (value == null) return;
+                      setState(() {
+                        _maquinaria = value;
+                      });
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                  _FormSectionLabel('Procedencia'),
+                  const SizedBox(height: 12),
+                  FormField<Set<String>>(
+                    initialValue: _procedencias,
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Selecciona al menos una procedencia';
+                      }
+                      return null;
+                    },
+                    builder: (state) {
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Wrap(
+                            spacing: 12,
+                            runSpacing: 12,
+                            children: _procedenciaOptions.map((option) {
+                              final selected = _procedencias.contains(option);
+                              return ChoiceChip(
+                                label: Text(option),
+                                selected: selected,
+                                selectedColor: palette.accent,
+                                backgroundColor: palette.surface,
+                                labelStyle: TextStyle(
+                                  color: selected
+                                      ? palette.onAccent
+                                      : palette.mutedText,
+                                  fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+                                ),
+                                onSelected: (value) {
+                                  setState(() {
+                                    if (value) {
+                                      _procedencias.add(option);
+                                    } else {
+                                      _procedencias.remove(option);
+                                    }
+                                  });
+                                  state.didChange(_procedencias);
+                                },
+                              );
+                            }).toList(),
+                          ),
+                          if (state.hasError)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8),
+                              child: Text(
+                                state.errorText!,
+                                style: TextStyle(
+                                  color: Theme.of(context).colorScheme.error,
+                                  fontSize: 12,
+                                ),
+                              ),
+                            ),
+                        ],
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                  _FormSectionLabel('Chute'),
+                  const SizedBox(height: 12),
+                  FormField<int>(
+                    initialValue: _selectedChute,
+                    builder: (state) {
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Wrap(
+                            spacing: 12,
+                            children: List.generate(5, (index) => index + 1).map((chute) {
+                              final selected = _selectedChute == chute;
+                              return ChoiceChip(
+                                label: Text('$chute'),
+                                selected: selected,
+                                selectedColor: palette.accent,
+                                backgroundColor: palette.surface,
+                                labelStyle: TextStyle(
+                                  color: selected
+                                      ? palette.onAccent
+                                      : palette.mutedText,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                                onSelected: (value) {
+                                  setState(() {
+                                    _selectedChute = chute;
+                                  });
+                                  state.didChange(_selectedChute);
+                                },
+                              );
+                            }).toList(),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                  TextFormField(
+                    controller: _fechaController,
+                    readOnly: true,
+                    style: TextStyle(color: palette.primaryText),
+                    decoration: InputDecoration(
+                      labelText: 'Fecha y hora de llegada al frente',
+                      suffixIcon: IconButton(
+                        onPressed: _selectFecha,
+                        icon: Icon(Icons.calendar_today, color: palette.mutedText),
+                      ),
+                    ),
+                    onTap: _selectFecha,
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _observacionesController,
+                    minLines: 3,
+                    maxLines: 4,
+                    style: TextStyle(color: palette.primaryText),
+                    decoration: const InputDecoration(
+                      labelText: 'Observaciones',
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  DropdownButtonFormField<VolqueteEstado>(
+                    value: _estado,
+                    decoration: const InputDecoration(
+                      labelText: 'Estado',
+                    ),
+                    dropdownColor: palette.surface,
+                    onChanged: isEditing
+                        ? null
+                        : (value) {
+                            if (value == null) return;
+                            setState(() {
+                              _estado = value;
+                            });
+                          },
+                    items: VolqueteEstado.values
+                        .map(
+                          (estado) => DropdownMenuItem<VolqueteEstado>(
+                            value: estado,
+                            child: Text(estado.label),
+                          ),
+                        )
+                        .toList(),
+                  ),
+                  const SizedBox(height: 32),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: _cancel,
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: palette.mutedText,
+                            side: BorderSide(color: palette.outline.withOpacity(0.5)),
+                            padding: const EdgeInsets.symmetric(vertical: 16),
+                          ),
+                          child: const Text('Cancelar'),
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: FilledButton(
+                          onPressed: _submit,
+                          style: FilledButton.styleFrom(
+                            backgroundColor: palette.accent,
+                            foregroundColor: palette.onAccent,
+                            padding: const EdgeInsets.symmetric(vertical: 16),
+                          ),
+                          child: const Text('Guardar'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FormSectionLabel extends StatelessWidget {
+  const _FormSectionLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+            letterSpacing: 0.6,
+          ),
+    );
+  }
+}
+
+class _QuickIcon extends StatelessWidget {
+  const _QuickIcon({required this.asset, this.size = 22});
+
+  final String asset;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    return CircleAvatar(
+      radius: 22,
+      backgroundColor: palette.surface,
+      child: SvgPicture.asset(
+        asset,
+        width: size,
+        height: size,
+        colorFilter: ColorFilter.mode(palette.icon, BlendMode.srcIn),
+      ),
+    );
+  }
+}
+
+class _EstadoChip extends StatelessWidget {
+  const _EstadoChip({required this.estado});
+
+  final VolqueteEstado estado;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    if (estado == VolqueteEstado.completo) {
+      return Text(
+        estado.label.substring(0, 1),
+        style: TextStyle(
+          color: palette.accent,
+          fontWeight: FontWeight.bold,
+          fontSize: 20,
+        ),
+      );
+    }
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: palette.accent.withOpacity(0.25),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(
+          color: palette.accent.withOpacity(0.4),
+        ),
+      ),
+      child: Text(
+        estado.label,
+        style: TextStyle(
+          color: palette.accent,
+          fontWeight: FontWeight.bold,
         ),
       ),
     );

--- a/lib/features/control_tiempos/presentation/pages/volquete_info_page.dart
+++ b/lib/features/control_tiempos/presentation/pages/volquete_info_page.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:toolmape/features/control_tiempos/domain/entities/volquete.dart';
+import 'package:toolmape/features/control_tiempos/presentation/theme/control_tiempos_palette.dart';
+
+class VolqueteInfoPage extends StatelessWidget {
+  VolqueteInfoPage({
+    super.key,
+    required this.volquete,
+  }) : _dateFormat = DateFormat('dd/MM/yyyy – HH:mm');
+
+  final Volquete volquete;
+  final DateFormat _dateFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final palette = ControlTiemposPalette.of(theme);
+
+    return Scaffold(
+      backgroundColor: palette.background,
+      appBar: AppBar(
+        backgroundColor: palette.background,
+        foregroundColor: palette.primaryText,
+        title: Text('Detalle de ${volquete.codigo}'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: [
+          Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: palette.surface,
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: palette.outline.withOpacity(0.4)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  volquete.maquinaria,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: palette.primaryText,
+                      ),
+                ),
+                const SizedBox(height: 8),
+                _InfoRow(label: 'Procedencia', value: volquete.procedencias.join(' / ')),
+                _InfoRow(label: 'Chute', value: 'Chute ${volquete.chute}'),
+                _InfoRow(
+                  label: 'Llegada a frente',
+                  value: _dateFormat.format(volquete.llegadaFrente),
+                ),
+                _InfoRow(
+                  label: 'Inicio de maniobra',
+                  value: volquete.inicioManiobra == null
+                      ? '—'
+                      : _dateFormat.format(volquete.inicioManiobra!),
+                ),
+                _InfoRow(
+                  label: 'Inicio de carga',
+                  value: volquete.inicioCarga == null
+                      ? '—'
+                      : _dateFormat.format(volquete.inicioCarga!),
+                ),
+                _InfoRow(
+                  label: 'Final de carga',
+                  value: volquete.finCarga == null
+                      ? '—'
+                      : _dateFormat.format(volquete.finCarga!),
+                ),
+                const SizedBox(height: 12),
+                _EstadoBadge(estado: volquete.estado),
+                if (volquete.notas != null && volquete.notas!.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  Text(
+                    'Observaciones',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                          color: palette.primaryText,
+                        ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    volquete.notas!,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                          color: palette.mutedText,
+                        ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Registros vinculados',
+            style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: palette.primaryText,
+                ),
+          ),
+          const SizedBox(height: 12),
+          _DescargasDataTable(volquete: volquete, dateFormat: _dateFormat),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: palette.subtleText,
+                  letterSpacing: 0.4,
+                ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: Theme.of(context)
+                .textTheme
+                .bodyMedium
+                ?.copyWith(color: palette.primaryText),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EstadoBadge extends StatelessWidget {
+  const _EstadoBadge({required this.estado});
+
+  final VolqueteEstado estado;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    final bool completo = estado == VolqueteEstado.completo;
+    final Color baseColor = completo ? palette.success : palette.accent;
+    final Color background = baseColor.withOpacity(completo ? 0.18 : 0.25);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: baseColor.withOpacity(0.4)),
+      ),
+      child: Text(
+        estado.label,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: baseColor,
+              fontWeight: FontWeight.bold,
+            ),
+      ),
+    );
+  }
+}
+
+class _DescargasDataTable extends StatelessWidget {
+  const _DescargasDataTable({required this.volquete, required this.dateFormat});
+
+  final Volquete volquete;
+  final DateFormat dateFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = ControlTiemposPalette.of(Theme.of(context));
+    if (volquete.descargas.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: palette.surface,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Text(
+          'Sin registros vinculados.',
+          style: Theme.of(context)
+              .textTheme
+              .bodyMedium
+              ?.copyWith(color: palette.mutedText),
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        headingRowColor:
+            WidgetStatePropertyAll(palette.surface.withOpacity(0.4)),
+        columns: [
+          DataColumn(label: Text('Volquete', style: TextStyle(color: palette.mutedText))),
+          DataColumn(label: Text('Procedencia', style: TextStyle(color: palette.mutedText))),
+          DataColumn(label: Text('Chute', style: TextStyle(color: palette.mutedText))),
+          DataColumn(label: Text('Fechas', style: TextStyle(color: palette.mutedText))),
+        ],
+        rows: volquete.descargas
+            .map(
+              (descarga) => DataRow(
+                cells: [
+                  DataCell(Text(descarga.volquete,
+                      style: TextStyle(color: palette.primaryText))),
+                  DataCell(Text(descarga.procedencia,
+                      style: TextStyle(color: palette.primaryText))),
+                  DataCell(Text(descarga.chute.toString(),
+                      style: TextStyle(color: palette.primaryText))),
+                  DataCell(
+                    Text(
+                      '${dateFormat.format(descarga.fechaInicio)}\n${dateFormat.format(descarga.fechaFin)}',
+                      style: TextStyle(color: palette.subtleText),
+                    ),
+                  ),
+                ],
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}

--- a/lib/features/control_tiempos/presentation/theme/control_tiempos_palette.dart
+++ b/lib/features/control_tiempos/presentation/theme/control_tiempos_palette.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+import 'package:toolmape/core/theme/extensions/app_colors.dart';
+
+class ControlTiemposPalette {
+  const ControlTiemposPalette({
+    required this.background,
+    required this.surface,
+    required this.outline,
+    required this.accent,
+    required this.onAccent,
+    required this.primaryText,
+    required this.mutedText,
+    required this.subtleText,
+    required this.icon,
+    required this.hint,
+    required this.searchFill,
+    required this.success,
+    required this.tabContainer,
+    required this.emptyIcon,
+    required this.selectionFill,
+    required this.selectionBorder,
+  });
+
+  final Color background;
+  final Color surface;
+  final Color outline;
+  final Color accent;
+  final Color onAccent;
+  final Color primaryText;
+  final Color mutedText;
+  final Color subtleText;
+  final Color icon;
+  final Color hint;
+  final Color searchFill;
+  final Color success;
+  final Color tabContainer;
+  final Color emptyIcon;
+  final Color selectionFill;
+  final Color selectionBorder;
+
+  factory ControlTiemposPalette.of(ThemeData theme) {
+    final scheme = theme.colorScheme;
+    final bool isDark = scheme.brightness == Brightness.dark;
+    final appColors = theme.extension<AppColors>();
+
+    final Color background = theme.scaffoldBackgroundColor;
+    final Color surface = theme.cardColor;
+    final Color outline = scheme.outline.withOpacity(isDark ? 0.35 : 0.5);
+    final Color accent = scheme.secondary;
+    final Color onAccent = scheme.onSecondary;
+    final Color primaryText = scheme.onSurface;
+    final Color mutedText = scheme.onSurface.withOpacity(isDark ? 0.78 : 0.7);
+    final Color subtleText = scheme.onSurfaceVariant;
+    final Color icon = scheme.onSurface;
+    final Color hint = scheme.onSurface.withOpacity(isDark ? 0.5 : 0.45);
+    final Color searchFill = theme.inputDecorationTheme.fillColor ??
+        scheme.surfaceVariant.withOpacity(isDark ? 0.35 : 0.85);
+    final Color success = appColors?.success ?? const Color(0xFF4CAF50);
+    final Color tabContainer =
+        scheme.surfaceVariant.withOpacity(isDark ? 0.45 : 0.9);
+    final Color emptyIcon = scheme.onSurface.withOpacity(0.25);
+    final Color selectionFill = accent.withOpacity(isDark ? 0.18 : 0.2);
+    final Color selectionBorder = accent.withOpacity(isDark ? 0.8 : 0.6);
+
+    return ControlTiemposPalette(
+      background: background,
+      surface: surface,
+      outline: outline,
+      accent: accent,
+      onAccent: onAccent,
+      primaryText: primaryText,
+      mutedText: mutedText,
+      subtleText: subtleText,
+      icon: icon,
+      hint: hint,
+      searchFill: searchFill,
+      success: success,
+      tabContainer: tabContainer,
+      emptyIcon: emptyIcon,
+      selectionFill: selectionFill,
+      selectionBorder: selectionBorder,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement multi-selection controls in the Control de Tiempos list so users can bulk-complete volquetes and manage selection state
- add a ControlTiemposPalette to derive colors from the active theme and remove hard-coded dark styling
- update the detail, form, and info screens to consume the palette so the module honors global theme settings

## Testing
- not run (Flutter CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e12d2f148083289a5cd43532885639