### PR TITLE
feat: sync control de tiempos con Supabase

### DIFF
--- a/lib/features/control_tiempos/infrastructure/datasources/volquetes_supabase_datasource.dart
+++ b/lib/features/control_tiempos/infrastructure/datasources/volquetes_supabase_datasource.dart
@@ -1,0 +1,230 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:toolmape/features/control_tiempos/domain/entities/volquete.dart';
+
+/// Exception thrown when Supabase operations for volquetes fail.
+class VolquetesDatasourceException implements Exception {
+  VolquetesDatasourceException(this.message, [this.cause]);
+
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() => 'VolquetesDatasourceException: ' '$message';
+}
+
+/// Datasource in charge of synchronising volquetes with Supabase.
+class VolquetesSupabaseDatasource {
+  VolquetesSupabaseDatasource(this._client);
+
+  final SupabaseClient _client;
+
+  static const _volquetesTable = 'control_tiempos_volquetes';
+  static const _eventosTable = 'control_tiempos_eventos';
+
+  Future<List<Volquete>> fetchVolquetes() async {
+    try {
+      final response = await _client
+          .from(_volquetesTable)
+          .select(
+            'id,codigo,placa,operador,destino,fecha,estado,tipo,equipo,documento,notas,'
+            'eventos:$_eventosTable(id,titulo,descripcion,fecha)',
+          )
+          .order('fecha', ascending: false);
+
+      final List<dynamic> rows = response as List<dynamic>;
+      return rows
+          .map((row) => _mapVolqueteFromRow(row as Map<String, dynamic>))
+          .toList();
+    } catch (error) {
+      throw VolquetesDatasourceException(
+        'No se pudieron obtener los volquetes desde Supabase.',
+        error,
+      );
+    }
+  }
+
+  Future<Volquete> upsertVolquete(Volquete volquete) async {
+    try {
+      final payload = _mapVolqueteToRow(volquete);
+
+      final upserted = await _client
+          .from(_volquetesTable)
+          .upsert(payload, onConflict: 'id')
+          .select(
+            'id,codigo,placa,operador,destino,fecha,estado,tipo,equipo,documento,notas,'
+            'eventos:$_eventosTable(id,titulo,descripcion,fecha)',
+          )
+          .maybeSingle();
+
+      final dynamic rawId = upserted?['id'] ?? payload['id'];
+      final String? maybeId = rawId == null ? null : rawId.toString().trim();
+
+      if ((maybeId == null || maybeId.isEmpty) && _isTemporaryId(volquete.id)) {
+        throw VolquetesDatasourceException(
+          'Supabase no devolvió un identificador para el nuevo volquete.',
+        );
+      }
+
+      final String volqueteId = (maybeId == null || maybeId.isEmpty)
+          ? volquete.id
+          : maybeId;
+
+      // Replace events with the provided list to keep them in sync.
+      await _client
+          .from(_eventosTable)
+          .delete()
+          .eq('volquete_id', volqueteId);
+
+      if (volquete.eventos.isNotEmpty) {
+        final eventosPayload = volquete.eventos.map((evento) {
+          return {
+            'volquete_id': volqueteId,
+            'titulo': evento.titulo,
+            'descripcion': evento.descripcion,
+            'fecha': evento.fecha.toIso8601String(),
+          };
+        }).toList();
+
+        await _client.from(_eventosTable).insert(eventosPayload);
+      }
+
+      final refreshed = await _client
+          .from(_volquetesTable)
+          .select(
+            'id,codigo,placa,operador,destino,fecha,estado,tipo,equipo,documento,notas,'
+            'eventos:$_eventosTable(id,titulo,descripcion,fecha)',
+          )
+          .eq('id', volqueteId)
+          .maybeSingle();
+
+      if (refreshed == null) {
+        throw VolquetesDatasourceException(
+          'Supabase no devolvió el registro recién guardado.',
+        );
+      }
+
+      return _mapVolqueteFromRow(Map<String, dynamic>.from(refreshed));
+    } catch (error) {
+      throw VolquetesDatasourceException(
+        'No se pudo guardar el volquete en Supabase.',
+        error,
+      );
+    }
+  }
+
+  Future<void> deleteVolquete(String id) async {
+    try {
+      await _client.from(_eventosTable).delete().eq('volquete_id', id);
+      await _client.from(_volquetesTable).delete().eq('id', id);
+    } catch (error) {
+      throw VolquetesDatasourceException(
+        'No se pudo eliminar el volquete en Supabase.',
+        error,
+      );
+    }
+  }
+
+  Volquete _mapVolqueteFromRow(Map<String, dynamic> row) {
+    final estado = _parseEstado(row['estado'] as String?);
+    final tipo = _parseTipo(row['tipo'] as String?);
+    final equipo = _parseEquipo(row['equipo'] as String?);
+
+    final eventosData = row['eventos'] as List<dynamic>?;
+    final eventos = (eventosData ?? [])
+        .map((eventRow) => _mapEvento(eventRow as Map<String, dynamic>))
+        .toList()
+      ..sort((a, b) => a.fecha.compareTo(b.fecha));
+
+    return Volquete(
+      id: row['id'].toString(),
+      codigo: (row['codigo'] as String?) ?? '',
+      placa: (row['placa'] as String?) ?? '',
+      operador: (row['operador'] as String?) ?? '',
+      destino: (row['destino'] as String?) ?? '',
+      fecha: _parseDate(row['fecha']) ?? DateTime.now(),
+      estado: estado,
+      tipo: tipo,
+      equipo: equipo,
+      documento: row['documento'] as String?,
+      notas: row['notas'] as String?,
+      eventos: eventos,
+    );
+  }
+
+  Map<String, dynamic> _mapVolqueteToRow(Volquete volquete) {
+    final map = <String, dynamic>{
+      'codigo': volquete.codigo,
+      'placa': volquete.placa,
+      'operador': volquete.operador,
+      'destino': volquete.destino,
+      'fecha': volquete.fecha.toIso8601String(),
+      'estado': volquete.estado.name,
+      'tipo': volquete.tipo.name,
+      'equipo': volquete.equipo.name,
+      'documento': volquete.documento,
+      'notas': volquete.notas,
+    };
+
+    if (!_isTemporaryId(volquete.id)) {
+      map['id'] = volquete.id;
+    }
+
+    return map;
+  }
+
+  VolqueteEvento _mapEvento(Map<String, dynamic> row) {
+    return VolqueteEvento(
+      titulo: (row['titulo'] as String?) ?? '',
+      descripcion: (row['descripcion'] as String?) ?? '',
+      fecha: _parseDate(row['fecha']) ?? DateTime.now(),
+    );
+  }
+
+  DateTime? _parseDate(dynamic value) {
+    if (value == null) return null;
+    if (value is DateTime) return value;
+    if (value is String && value.isNotEmpty) {
+      return DateTime.tryParse(value);
+    }
+    return null;
+  }
+
+  VolqueteEstado _parseEstado(String? value) {
+    switch (value) {
+      case 'completo':
+        return VolqueteEstado.completo;
+      case 'pausado':
+        return VolqueteEstado.pausado;
+      case 'enProceso':
+      case 'en_proceso':
+        return VolqueteEstado.enProceso;
+      default:
+        return VolqueteEstado.enProceso;
+    }
+  }
+
+  VolqueteTipo _parseTipo(String? value) {
+    switch (value) {
+      case 'descarga':
+        return VolqueteTipo.descarga;
+      case 'carga':
+        return VolqueteTipo.carga;
+      default:
+        return VolqueteTipo.carga;
+    }
+  }
+
+  VolqueteEquipo _parseEquipo(String? value) {
+    switch (value) {
+      case 'excavadora':
+        return VolqueteEquipo.excavadora;
+      case 'cargador':
+        return VolqueteEquipo.cargador;
+      default:
+        return VolqueteEquipo.cargador;
+    }
+  }
+
+  bool _isTemporaryId(String id) => id.startsWith('local-');
+}

--- a/lib/features/control_tiempos/presentation/pages/control_tiempos_page.dart
+++ b/lib/features/control_tiempos/presentation/pages/control_tiempos_page.dart
@@ -3,10 +3,12 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:toolmape/app/router/routes.dart';
 import 'package:toolmape/app/shell/app_shell.dart';
 import 'package:toolmape/features/control_tiempos/domain/entities/volquete.dart';
+import 'package:toolmape/features/control_tiempos/infrastructure/datasources/volquetes_supabase_datasource.dart';
 import 'package:toolmape/features/control_tiempos/presentation/pages/volquete_detail_page.dart';
 import 'package:toolmape/features/control_tiempos/presentation/pages/volquete_form_page.dart';
 
@@ -35,7 +37,11 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
   final TextEditingController _searchController = TextEditingController();
   final DateFormat _dateFormat = DateFormat('dd/MM/yyyy – HH:mm');
 
-  late List<Volquete> _volquetes;
+  List<Volquete> _volquetes = const [];
+  VolquetesSupabaseDatasource? _datasource;
+  bool _isLoading = false;
+  bool _isOfflineMode = false;
+  String? _errorMessage;
   int _selectedBottomIndex = 0;
   String _searchTerm = '';
   Timer? _debounce;
@@ -51,7 +57,8 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
     super.initState();
     _tabController = TabController(length: 2, vsync: this);
     _tabController.addListener(_handleTabChanged);
-    _volquetes = _initialVolquetes;
+    _datasource = _maybeCreateDatasource();
+    _loadVolquetes();
   }
 
   @override
@@ -77,6 +84,145 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
     });
   }
 
+  VolquetesSupabaseDatasource? _maybeCreateDatasource() {
+    try {
+      final client = Supabase.instance.client;
+      return VolquetesSupabaseDatasource(client);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _loadVolquetes() async {
+    _datasource ??= _maybeCreateDatasource();
+
+    if (!mounted) return;
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    final datasource = _datasource;
+
+    if (datasource == null) {
+      setState(() {
+        _volquetes = _initialVolquetes;
+        _isOfflineMode = true;
+        _errorMessage = 'Configura las credenciales de Supabase para sincronizar tus volquetes.';
+        _isLoading = false;
+      });
+      return;
+    }
+
+    try {
+      final items = await datasource.fetchVolquetes();
+      if (!mounted) return;
+      setState(() {
+        _volquetes = items;
+        _isOfflineMode = false;
+        _errorMessage = null;
+      });
+    } on VolquetesDatasourceException catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _volquetes = _initialVolquetes;
+        _isOfflineMode = true;
+        _errorMessage = error.message;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _volquetes = _initialVolquetes;
+        _isOfflineMode = true;
+        _errorMessage = 'Error inesperado al conectar con Supabase.';
+      });
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _saveVolquete(Volquete volquete, {required bool isNew}) async {
+    _datasource ??= _maybeCreateDatasource();
+
+    var resolved = volquete;
+    var offline = false;
+    String? syncMessage;
+
+    try {
+      final datasource = _datasource;
+      if (datasource != null) {
+        resolved = await datasource.upsertVolquete(volquete);
+      } else {
+        offline = true;
+        syncMessage = 'Supabase no está configurado. Se guardó el registro localmente.';
+      }
+    } on VolquetesDatasourceException catch (error) {
+      offline = true;
+      syncMessage = error.message;
+    } catch (_) {
+      offline = true;
+      syncMessage = 'No se pudo sincronizar con Supabase. El registro se guardó de forma local.';
+    }
+
+    if (!mounted) return;
+
+    setState(() {
+      _isOfflineMode = offline;
+      _errorMessage = offline ? syncMessage : null;
+      final updatedList = _volquetes
+          .where((v) => v.id != volquete.id && v.id != resolved.id)
+          .toList()
+        ..add(resolved)
+        ..sort((a, b) => b.fecha.compareTo(a.fecha));
+      _volquetes = updatedList;
+    });
+
+    final message = offline
+        ? (isNew
+            ? 'Volquete registrado sin conexión.'
+            : 'Cambios guardados sin conexión.')
+        : (isNew ? 'Volquete registrado correctamente' : 'Volquete actualizado correctamente');
+
+    _showSnack(message);
+  }
+
+  Future<void> _deleteVolquete(String id) async {
+    _datasource ??= _maybeCreateDatasource();
+
+    var offline = false;
+    String? syncMessage;
+
+    try {
+      final datasource = _datasource;
+      if (datasource != null) {
+        await datasource.deleteVolquete(id);
+      } else {
+        offline = true;
+        syncMessage = 'Supabase no está configurado. Se eliminó el registro localmente.';
+      }
+    } on VolquetesDatasourceException catch (error) {
+      offline = true;
+      syncMessage = error.message;
+    } catch (_) {
+      offline = true;
+      syncMessage = 'No se pudo eliminar el volquete en Supabase.';
+    }
+
+    if (!mounted) return;
+
+    setState(() {
+      _volquetes = _volquetes.where((v) => v.id != id).toList();
+      _isOfflineMode = offline;
+      _errorMessage = offline ? syncMessage : null;
+    });
+
+    _showSnack(offline ? 'Volquete eliminado sin conexión.' : 'Volquete eliminado');
+  }
+
   Future<void> _openForm({Volquete? initial}) async {
     final result = await Navigator.push<Volquete>(
       context,
@@ -91,23 +237,7 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
 
     if (result == null) return;
 
-    setState(() {
-      final existingIndex = _volquetes.indexWhere((v) => v.id == result.id);
-      if (existingIndex >= 0) {
-        _volquetes[existingIndex] = result;
-      } else {
-        _volquetes = [..._volquetes, result];
-      }
-    });
-
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(initial == null
-            ? 'Volquete registrado correctamente'
-            : 'Volquete actualizado correctamente'),
-      ),
-    );
+    await _saveVolquete(result, isNew: initial == null);
   }
 
   Future<void> _openDetail(Volquete volquete) async {
@@ -121,29 +251,12 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
     if (result == null) return;
 
     if (result.deletedVolqueteId != null) {
-      setState(() {
-        _volquetes =
-            _volquetes.where((v) => v.id != result.deletedVolqueteId).toList();
-      });
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Volquete eliminado')),
-      );
+      await _deleteVolquete(result.deletedVolqueteId!);
       return;
     }
 
     if (result.updatedVolquete != null) {
-      setState(() {
-        final index =
-        _volquetes.indexWhere((v) => v.id == result.updatedVolquete!.id);
-        if (index >= 0) {
-          _volquetes[index] = result.updatedVolquete!;
-        }
-      });
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Volquete actualizado')),
-      );
+      await _saveVolquete(result.updatedVolquete!, isNew: false);
     }
   }
 
@@ -265,28 +378,51 @@ class _ControlTiemposPageState extends State<ControlTiemposPage>
                 ),
               ),
               const SizedBox(height: 16),
+              if (_isOfflineMode || _errorMessage != null) ...[
+                if (_isOfflineMode)
+                  const _StatusBanner(
+                    icon: Icons.cloud_off_outlined,
+                    message:
+                        'Operando sin conexión a Supabase. Los registros de cargadores y excavadoras se guardarán de forma local.',
+                  ),
+                if (_errorMessage != null) ...[
+                  if (_isOfflineMode) const SizedBox(height: 8),
+                  _StatusBanner(
+                    icon: Icons.info_outline,
+                    message: _errorMessage!,
+                  ),
+                ],
+                const SizedBox(height: 16),
+              ],
               Expanded(
-                child: _filteredVolquetes.isEmpty
-                    ? const _EmptyVolquetesView()
-                    : ListView.separated(
-                  itemCount: _filteredVolquetes.length,
-                  separatorBuilder: (_, __) => const SizedBox(height: 12),
-                  itemBuilder: (_, index) {
-                    final volquete = _filteredVolquetes[index];
-                    return _VolqueteCard(
-                      volquete: volquete,
-                      dateFormat: _dateFormat,
-                      onTap: () => _openDetail(volquete),
-                      onEdit: () => _openForm(initial: volquete),
-                      onViewDocument: () => _showSnack(
-                        'Documento ${volquete.documento ?? 'no disponible'}',
-                      ),
-                      onViewVolquete: () => _openDetail(volquete),
-                      onNavigate: () => _showSnack(
-                        'Navegando a ${volquete.destino}',
-                      ),
-                    );
-                  },
+                child: RefreshIndicator(
+                  onRefresh: _loadVolquetes,
+                  child: _isLoading
+                      ? const _LoadingVolquetesView()
+                      : _filteredVolquetes.isEmpty
+                          ? const _EmptyVolquetesView()
+                          : ListView.separated(
+                              physics: const AlwaysScrollableScrollPhysics(),
+                              padding: const EdgeInsets.only(bottom: 80),
+                              itemCount: _filteredVolquetes.length,
+                              separatorBuilder: (_, __) => const SizedBox(height: 12),
+                              itemBuilder: (_, index) {
+                                final volquete = _filteredVolquetes[index];
+                                return _VolqueteCard(
+                                  volquete: volquete,
+                                  dateFormat: _dateFormat,
+                                  onTap: () => _openDetail(volquete),
+                                  onEdit: () => _openForm(initial: volquete),
+                                  onViewDocument: () => _showSnack(
+                                    'Documento ${volquete.documento ?? 'no disponible'}',
+                                  ),
+                                  onViewVolquete: () => _openDetail(volquete),
+                                  onNavigate: () => _showSnack(
+                                    'Navegando a ${volquete.destino}',
+                                  ),
+                                );
+                              },
+                            ),
                 ),
               ),
             ],
@@ -392,21 +528,84 @@ class _EmptyVolquetesView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(Icons.inbox_outlined, size: 64, color: Colors.grey.shade400),
-          const SizedBox(height: 12),
-          const Text('No se encontraron registros'),
-          const SizedBox(height: 4),
-          Text(
+    final theme = Theme.of(context);
+    final subtle = theme.textTheme.bodyMedium?.copyWith(
+      color: Colors.grey.shade500,
+    );
+
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        const SizedBox(height: 48),
+        Icon(Icons.inbox_outlined, size: 64, color: Colors.grey.shade400),
+        const SizedBox(height: 12),
+        Text(
+          'No se encontraron registros',
+          style: theme.textTheme.titleMedium,
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 4),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Text(
             'Ajusta los filtros o registra un nuevo volquete.',
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium
-                ?.copyWith(color: Colors.grey.shade600),
+            style: subtle,
             textAlign: TextAlign.center,
+          ),
+        ),
+        const SizedBox(height: 160),
+      ],
+    );
+  }
+}
+
+class _LoadingVolquetesView extends StatelessWidget {
+  const _LoadingVolquetesView();
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: const [
+        SizedBox(height: 120),
+        Center(child: CircularProgressIndicator()),
+        SizedBox(height: 160),
+      ],
+    );
+  }
+}
+
+class _StatusBanner extends StatelessWidget {
+  const _StatusBanner({required this.icon, required this.message});
+
+  final IconData icon;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final background = scheme.secondaryContainer.withOpacity(0.25);
+    final borderColor = scheme.outline.withOpacity(0.35);
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: borderColor),
+      ),
+      padding: const EdgeInsets.all(12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: scheme.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              message,
+              style: theme.textTheme.bodyMedium,
+            ),
           ),
         ],
       ),

--- a/lib/features/control_tiempos/presentation/pages/volquete_form_page.dart
+++ b/lib/features/control_tiempos/presentation/pages/volquete_form_page.dart
@@ -105,7 +105,7 @@ class _VolqueteFormPageState extends State<VolqueteFormPage> {
         ];
 
     final volquete = Volquete(
-      id: widget.initial?.id ?? DateTime.now().millisecondsSinceEpoch.toString(),
+      id: widget.initial?.id ?? 'local-${DateTime.now().millisecondsSinceEpoch}',
       codigo: _codigoController.text.trim(),
       placa: _placaController.text.trim(),
       operador: _operadorController.text.trim(),


### PR DESCRIPTION
## Summary
- add a Supabase datasource for volquetes that fetches, persists, and deletes registros with their eventos
- wire the Control de tiempos page to the datasource with offline fallbacks, pull-to-refresh, and status banners
- create stable local identifiers for newly registrados volquetes until Supabase assigns one

## Testing
- not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e68833ec688328bf10833873daec24